### PR TITLE
Правит action для обновления data-файлов

### DIFF
--- a/.github/scripts/update-index.js
+++ b/.github/scripts/update-index.js
@@ -4,33 +4,37 @@ const fs = require('fs')
 const { promisify } = require('util')
 const { exec } = require('child_process')
 
-// получение id последнего коммита
-const lastCommitId = 'git log --diff-filter=AMCR --format="%H" -n 1'
-
-// получение изменённых и добавленных файлов последнего коммита
-const gitCommand = `git diff-tree --no-commit-id --name-only -r $(echo $(${lastCommitId}))`
-
-const tags = ['html', 'css', 'js', 'tools']
-
 async function main() {
-  const { stdout } = await promisify(exec)(gitCommand)
+  // получение id последнего коммита
+  const lastCommitId = 'git log --diff-filter=AMCR --format="%H" -n 1'
+  // получение изменённых и добавленных файлов последнего коммита
+  const gitCommand = `git diff-tree --no-commit-id --name-only -r $(echo $(${lastCommitId}))`
+
+  const { stdout }= await promisify(exec)(gitCommand)
 
   const filePaths = stdout.split(os.EOL)
     .map(filePath => filePath.trim())
     .filter(Boolean)
-    // учитываем только файлы, находящиеся в папках статей
     .filter(filePath => {
-      const tag = filePath.split(path.sep).filter(Boolean)[0]
-      return tags.includes(tag)
+      const pathSegments = filePath.split(path.sep).filter(Boolean)
+      const tag = pathSegments[0]
+
+      return [
+        // учитываем только файлы, находящиеся в папках статей
+        ['html', 'css', 'js', 'tools'].includes(tag),
+        // не учитывем файлы индексов статей, например, 'css/index.md'
+        pathSegments.length >= 3,
+      ].every(Boolean)
     })
     // возвращаем путь до папки самой статьи
     .map(filePath => {
       const [tag, articleName] = filePath.split(path.sep).filter(Boolean)
       return [tag, articleName].join(path.sep)
-    });
+    })
 
   // используем Set, так как могут быть дубли в путях
   const filePathsSet = new Set(filePaths)
+
   filePathsSet.forEach(filePath => {
     if (!fs.existsSync(filePath)) {
       return

--- a/.github/workflows/updated-at-field.yml
+++ b/.github/workflows/updated-at-field.yml
@@ -6,12 +6,13 @@ on:
       - main
 
 jobs:
-  spell:
+  update-index:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
         with:
           token: ${{ secrets.DOKA_BOT_ACCESS_TOKEN }}
+          fetch-depth: 2
       - uses: actions/setup-node@v2
         with:
           node-version: '14'

--- a/.github/workflows/updated-at-field.yml
+++ b/.github/workflows/updated-at-field.yml
@@ -16,11 +16,11 @@ jobs:
       - uses: actions/setup-node@v2
         with:
           node-version: '14'
-      - name: Правка поля updatedAt
+      - name: Правка полей updatedAt и createdAt
         run: node .github/scripts/update-index.js
       - uses: stefanzweifel/git-auto-commit-action@v4
         with:
-          commit_message: Правит дату последнего изменения статьи
+          commit_message: Правит поля updatedAt и createdAt
           file_pattern: ./**/index.11tydata.json
           commit_user_name: Doka Dog
           commit_user_email: hi@doka.guide


### PR DESCRIPTION
Fix: #1122

Похоже, что основная проблема была в том, что _action/chekout_ скачивает только последний коммит, но для работы команды `git diff-tree` нужны как минимум два, чтобы построить список файлов.

Плюс добавил в игнор изменения файлов индексов статей, которые будут в _css/index.md_, _html/index.md_ и др.