### PR TITLE
Изменяет заголовок статьи о тулинге на Node.js

### DIFF
--- a/tools/nodejs-tooling/index.md
+++ b/tools/nodejs-tooling/index.md
@@ -1,5 +1,5 @@
 ---
-title: "Что такое Node.js?"
+title: "Node.js для создания инструментов разработки"
 tags:
   - article
 authors:


### PR DESCRIPTION
Сейчас есть две статьи с заголовком «Что такое Node.js?». Этот пул реквест правит заголовок одной из них