### PR TITLE
Правит мету в статье про Липкое позиционирование

### DIFF
--- a/css/sticky/index.md
+++ b/css/sticky/index.md
@@ -2,7 +2,7 @@
 title: "Липкое позиционирование"
 tags:
   - doka
-authors: 
+authors:
   - lenaryan
 editors:
   - tachisis

--- a/css/sticky/index.md
+++ b/css/sticky/index.md
@@ -1,8 +1,9 @@
 ---
 title: "Липкое позиционирование"
-tag:
+tags:
   - doka
-author: lenaryan
+authors: 
+  - lenaryan
 editors:
   - tachisis
 summary:


### PR DESCRIPTION
Правит мету, фиксит сломанную ссылку на статью