### PR TITLE
Правит мету в статье про float

### DIFF
--- a/css/float/index.md
+++ b/css/float/index.md
@@ -1,6 +1,9 @@
 ---
 title: "float"
-author: lenaryan
+tags:
+  - doka
+authors:
+  - lenaryan
 editors:
   - tachisis
 summary:


### PR DESCRIPTION
Правит мету, фиксит сломанную ссылку на статью