### PR TITLE
Правит название статьи

### DIFF
--- a/js/element-outerhtml/index.md
+++ b/js/element-outerhtml/index.md
@@ -1,9 +1,9 @@
 ---
-title: "Element.innerHTML"
+title: "Element.outerHTML"
 tags:
   - doka
 authors:
-  - Windrushfarer
+  - windrushfarer
 ---
 
 ## Кратко


### PR DESCRIPTION
Кажется немного перепутали :) Плюс записывает ник строчными, как и название папки [в people](https://github.com/doka-guide/content/tree/main/people).