### PR TITLE
Исправляет команду для проверки нужных папок

### DIFF
--- a/.github/scripts/frontmatter.js
+++ b/.github/scripts/frontmatter.js
@@ -28,6 +28,12 @@ const rawMeta = fs.readFileSync('result.json')
 const settings = fs.readFileSync('.frontmatter.json')
 
 const commonMeta = JSON.parse(rawMeta)
+
+if (commonMeta.hasOwnProperty('css/index.md')) delete commonMeta['css/index.md']
+if (commonMeta.hasOwnProperty('html/index.md')) delete commonMeta['html/index.md']
+if (commonMeta.hasOwnProperty('js/index.md')) delete commonMeta['js/index.md']
+if (commonMeta.hasOwnProperty('tools/index.md')) delete commonMeta['tools/index.md']
+
 const { requireField, requireOrder } = JSON.parse(settings)
 let errorRequiredFieldsCounter = 0
 let errorOrderFieldsCounter = 0

--- a/.github/scripts/frontmatter.js
+++ b/.github/scripts/frontmatter.js
@@ -24,15 +24,21 @@ const isRequireFieldExists = (fileName, fileMeta, field) => {
   return true
 }
 
+const processIndexFile = (fileName) => {
+  if (commonMeta.hasOwnProperty(fileName)){
+    delete commonMeta[fileName]
+  }
+}
+
 const rawMeta = fs.readFileSync('result.json')
 const settings = fs.readFileSync('.frontmatter.json')
 
 const commonMeta = JSON.parse(rawMeta)
 
-if (commonMeta.hasOwnProperty('css/index.md')) delete commonMeta['css/index.md']
-if (commonMeta.hasOwnProperty('html/index.md')) delete commonMeta['html/index.md']
-if (commonMeta.hasOwnProperty('js/index.md')) delete commonMeta['js/index.md']
-if (commonMeta.hasOwnProperty('tools/index.md')) delete commonMeta['tools/index.md']
+processIndexFile('css/index.md')
+processIndexFile('html/index.md')
+processIndexFile('js/index.md')
+processIndexFile('tools/index.md')
 
 const { requireField, requireOrder } = JSON.parse(settings)
 let errorRequiredFieldsCounter = 0

--- a/.github/workflows/frontmatter-lint.yml
+++ b/.github/workflows/frontmatter-lint.yml
@@ -4,7 +4,6 @@ on:
   push:
     branches:
       - main
-  pull_request:
 
 jobs:
   lint:

--- a/.github/workflows/frontmatter-lint.yml
+++ b/.github/workflows/frontmatter-lint.yml
@@ -4,6 +4,7 @@ on:
   push:
     branches:
       - main
+  pull_request:
 
 jobs:
   lint:

--- a/.github/workflows/frontmatter-lint.yml
+++ b/.github/workflows/frontmatter-lint.yml
@@ -16,7 +16,7 @@ jobs:
       - name: Проверка линтером в main
         run: |
           echo "Проверка для всех файлов"
-          npx yaml-cat -f json (css|html|js|tools)/**/index.md -o result.json
+          npx yaml-cat --format json --output result.json css/**/index.md html/**/index.md js/**/index.md tools/**/index.md
           node .github/scripts/frontmatter.js --fix
       - uses: stefanzweifel/git-auto-commit-action@v4
         with:

--- a/tools/network/index.md
+++ b/tools/network/index.md
@@ -1,6 +1,5 @@
 ---
 title: "Работа с сетью"
-name: network
 authors:
   - igsekor
 contributors:

--- a/tools/xml/index.md
+++ b/tools/xml/index.md
@@ -2,7 +2,7 @@
 title: "XML"
 authors:
   - KognitivnayaBuena
-symmary:
+keywords:
   - xml
   - разметка
 tags:


### PR DESCRIPTION
При проверке меты возникала ошибка, связанная с некорректной командой для bas-скрипта. При выполнении команды отдельно в консоле проблемы не возникало. Теперь всё работает корректно, хотя код и стал менее читаемый.