### PR TITLE
Расставляет бэктики для кода в заголовках CSS

### DIFF
--- a/css/active/index.md
+++ b/css/active/index.md
@@ -1,5 +1,5 @@
 ---
-title: ":active"
+title: "`:active`"
 authors:
   - solarrust
 editors:

--- a/css/after/index.md
+++ b/css/after/index.md
@@ -1,5 +1,5 @@
 ---
-title: "::after"
+title: "`::after`"
 authors:
   - ezhkov
 contributors:

--- a/css/align-content/index.md
+++ b/css/align-content/index.md
@@ -1,5 +1,5 @@
 ---
-title: "align-content"
+title: "`align-content`"
 authors:
   - solarrust
 editors:

--- a/css/align-items/index.md
+++ b/css/align-items/index.md
@@ -1,5 +1,5 @@
 ---
-title: "align-items"
+title: "`align-items`"
 authors:
   - solarrust
 editors:

--- a/css/align-self/index.md
+++ b/css/align-self/index.md
@@ -1,5 +1,5 @@
 ---
-title: "align-self"
+title: "`align-self`"
 authors:
   - solarrust
 editors:

--- a/css/all/index.md
+++ b/css/all/index.md
@@ -1,5 +1,5 @@
 ---
-title: "all"
+title: "`all`"
 authors:
   - doka-dog
 keywords:

--- a/css/animation-delay/index.md
+++ b/css/animation-delay/index.md
@@ -1,5 +1,5 @@
 ---
-title: "animation-delay"
+title: "`animation-delay`"
 authors:
   - solarrust
 editors:

--- a/css/animation-direction/index.md
+++ b/css/animation-direction/index.md
@@ -1,5 +1,5 @@
 ---
-title: "animation-direction"
+title: "`animation-direction`"
 authors:
   - solarrust
 editors:

--- a/css/animation-duration/index.md
+++ b/css/animation-duration/index.md
@@ -1,5 +1,5 @@
 ---
-title: "animation-duration"
+title: "`animation-duration`"
 authors:
   - solarrust
 editors:

--- a/css/animation-fill-mode/index.md
+++ b/css/animation-fill-mode/index.md
@@ -1,5 +1,5 @@
 ---
-title: "animation-fill-mode"
+title: "`animation-fill-mode`"
 authors:
   - solarrust
 editors:

--- a/css/animation-iteration-count/index.md
+++ b/css/animation-iteration-count/index.md
@@ -1,5 +1,5 @@
 ---
-title: "animation-iteration-count"
+title: "`animation-iteration-count`"
 authors:
   - solarrust
 editors:

--- a/css/animation-name/index.md
+++ b/css/animation-name/index.md
@@ -1,5 +1,5 @@
 ---
-title: "animation-name"
+title: "`animation-name`"
 authors:
   - solarrust
 editors:

--- a/css/animation-play-state/index.md
+++ b/css/animation-play-state/index.md
@@ -1,5 +1,5 @@
 ---
-title: "animation-play-state"
+title: "`animation-play-state`"
 authors:
   - solarrust
 editors:

--- a/css/animation-timing-function/index.md
+++ b/css/animation-timing-function/index.md
@@ -1,5 +1,5 @@
 ---
-title: "animation-timing-function"
+title: "`animation-timing-function`"
 authors:
   - solarrust
 editors:

--- a/css/appearance/index.md
+++ b/css/appearance/index.md
@@ -1,5 +1,5 @@
 ---
-title: "appearance"
+title: "`appearance`"
 authors:
   - ezhkov
 editors:

--- a/css/attr/index.md
+++ b/css/attr/index.md
@@ -1,5 +1,5 @@
 ---
-title: "attr()"
+title: "`attr()`"
 authors:
   - ezhkov
 editors:

--- a/css/background-attachment/index.md
+++ b/css/background-attachment/index.md
@@ -1,5 +1,5 @@
 ---
-title: "background-attachment"
+title: "`background-attachment`"
 authors:
   - doka-dog
 keywords:

--- a/css/background-blend-mode/index.md
+++ b/css/background-blend-mode/index.md
@@ -1,5 +1,5 @@
 ---
-title: "background-blend-mode"
+title: "`background-blend-mode`"
 authors:
   - doka-dog
 keywords:

--- a/css/background-clip/index.md
+++ b/css/background-clip/index.md
@@ -1,5 +1,5 @@
 ---
-title: "background-clip"
+title: "`background-clip`"
 authors:
   - doka-dog
 keywords:

--- a/css/background-color/index.md
+++ b/css/background-color/index.md
@@ -1,5 +1,5 @@
 ---
-title: "background-color"
+title: "`background-color`"
 authors:
   - solarrust
 contributors:

--- a/css/background-image/index.md
+++ b/css/background-image/index.md
@@ -1,5 +1,5 @@
 ---
-title: "background-image"
+title: "`background-image`"
 authors:
   - grachev
 contributors:

--- a/css/background-origin/index.md
+++ b/css/background-origin/index.md
@@ -1,5 +1,5 @@
 ---
-title: "background-origin"
+title: "`background-origin`"
 authors:
   - doka-dog
 keywords:

--- a/css/background-position/index.md
+++ b/css/background-position/index.md
@@ -1,5 +1,5 @@
 ---
-title: "background-position"
+title: "`background-position`"
 authors:
   - solarrust
 contributors:

--- a/css/background-repeat/index.md
+++ b/css/background-repeat/index.md
@@ -1,5 +1,5 @@
 ---
-title: "background-repeat"
+title: "`background-repeat`"
 authors:
   - solarrust
 contributors:

--- a/css/background-size/index.md
+++ b/css/background-size/index.md
@@ -1,5 +1,5 @@
 ---
-title: "background-size"
+title: "`background-size`"
 authors:
   - solarrust
 contributors:

--- a/css/background/index.md
+++ b/css/background/index.md
@@ -1,5 +1,5 @@
 ---
-title: "background"
+title: "`background`"
 authors:
   - solarrust
 keywords:

--- a/css/before/index.md
+++ b/css/before/index.md
@@ -1,5 +1,5 @@
 ---
-title: "::before"
+title: "`::before`"
 authors:
   - ezhkov
 contributors:

--- a/css/border-image/index.md
+++ b/css/border-image/index.md
@@ -1,5 +1,5 @@
 ---
-title: "border-image"
+title: "`border-image`"
 authors:
   - solarrust
 contributors:

--- a/css/border-radius/index.md
+++ b/css/border-radius/index.md
@@ -1,5 +1,5 @@
 ---
-title: "border-radius"
+title: "`border-radius`"
 authors:
   - solarrust
 contributors:

--- a/css/border/index.md
+++ b/css/border/index.md
@@ -1,5 +1,5 @@
 ---
-title: "border"
+title: "`border`"
 authors:
   - solarrust
 contributors:

--- a/css/box-shadow/index.md
+++ b/css/box-shadow/index.md
@@ -1,5 +1,5 @@
 ---
-title: "box-shadow"
+title: "`box-shadow`"
 authors:
   - solarrust
 contributors:

--- a/css/box-sizing/index.md
+++ b/css/box-sizing/index.md
@@ -1,5 +1,5 @@
 ---
-title: "box-sizing"
+title: "`box-sizing`"
 authors:
   - solarrust
 contributors:

--- a/css/calc/index.md
+++ b/css/calc/index.md
@@ -1,5 +1,5 @@
 ---
-title: "calc()"
+title: "`calc()`"
 authors:
   - solarrust
 contributors:

--- a/css/checked/index.md
+++ b/css/checked/index.md
@@ -1,5 +1,5 @@
 ---
-title: ":checked"
+title: "`:checked`"
 authors:
   - solarrust
 contributors:

--- a/css/child/index.md
+++ b/css/child/index.md
@@ -1,5 +1,5 @@
 ---
-title: "Псевдоклассы группы `child`"
+title: "Псевдоклассы группы child"
 authors:
   - solarrust
 contributors:

--- a/css/child/index.md
+++ b/css/child/index.md
@@ -1,5 +1,5 @@
 ---
-title: "Псевдоклассы группы child"
+title: "Псевдоклассы группы `child`"
 authors:
   - solarrust
 contributors:

--- a/css/color/index.md
+++ b/css/color/index.md
@@ -1,5 +1,5 @@
 ---
-title: "color"
+title: "`color`"
 authors:
   - grachev
 contributors:

--- a/css/column-row-gap/index.md
+++ b/css/column-row-gap/index.md
@@ -1,5 +1,5 @@
 ---
-title: "column-gap, row-gap"
+title: "`column-gap`, `row-gap`"
 authors:
   - solarrust
 keywords:

--- a/css/content/index.md
+++ b/css/content/index.md
@@ -1,5 +1,5 @@
 ---
-title: "content"
+title: "`content`"
 authors:
   - ezhkov
 contributors:

--- a/css/cursor/index.md
+++ b/css/cursor/index.md
@@ -1,5 +1,5 @@
 ---
-title: "cursor"
+title: "`cursor`"
 authors:
   - solarrust
 contributors:

--- a/css/disabled-enabled/index.md
+++ b/css/disabled-enabled/index.md
@@ -1,5 +1,5 @@
 ---
-title: ":disabled и :enabled"
+title: "`:disabled` и `:enabled`"
 authors:
   - solarrust
 contributors:

--- a/css/display/index.md
+++ b/css/display/index.md
@@ -1,5 +1,5 @@
 ---
-title: "display"
+title: "`display`"
 authors:
   - solarrust
 contributors:

--- a/css/empty/index.md
+++ b/css/empty/index.md
@@ -1,5 +1,5 @@
 ---
-title: ":empty"
+title: "`:empty`"
 authors:
   - ezhkov
 editors:

--- a/css/fill/index.md
+++ b/css/fill/index.md
@@ -1,5 +1,5 @@
 ---
-title: "fill"
+title: "`fill`"
 authors:
   - realetive
 keywords:

--- a/css/first-letter/index.md
+++ b/css/first-letter/index.md
@@ -1,5 +1,5 @@
 ---
-title: "::first-letter"
+title: "`::first-letter`"
 authors:
   - doka-dog
 keywords:

--- a/css/first-line/index.md
+++ b/css/first-line/index.md
@@ -1,5 +1,5 @@
 ---
-title: "::first-line"
+title: "`::first-line`"
 authors:
   - doka-dog
 keywords:

--- a/css/flex-basis/index.md
+++ b/css/flex-basis/index.md
@@ -1,5 +1,5 @@
 ---
-title: "flex-basis"
+title: "`flex-basis`"
 authors:
   - solarrust
 editors:

--- a/css/flex-flow/index.md
+++ b/css/flex-flow/index.md
@@ -1,5 +1,5 @@
 ---
-title: "flex-flow"
+title: "`flex-flow`"
 authors:
   - solarrust
 editors:

--- a/css/flex-grow/index.md
+++ b/css/flex-grow/index.md
@@ -1,5 +1,5 @@
 ---
-title: "flex-grow"
+title: "`flex-grow`"
 authors:
   - solarrust
 editors:

--- a/css/flex-shrink/index.md
+++ b/css/flex-shrink/index.md
@@ -1,5 +1,5 @@
 ---
-title: "flex-shrink"
+title: "`flex-shrink`"
 authors:
   - solarrust
 editors:

--- a/css/flex-wrap/index.md
+++ b/css/flex-wrap/index.md
@@ -1,5 +1,5 @@
 ---
-title: "flex-wrap"
+title: "`flex-wrap`"
 authors:
   - solarrust
 editors:

--- a/css/flex/index.md
+++ b/css/flex/index.md
@@ -1,5 +1,5 @@
 ---
-title: "flex"
+title: "`flex`"
 authors:
   - solarrust
 editors:

--- a/css/float/index.md
+++ b/css/float/index.md
@@ -1,5 +1,5 @@
 ---
-title: "float"
+title: "`float`"
 authors:
   - lenaryan
 editors:

--- a/css/focus/index.md
+++ b/css/focus/index.md
@@ -1,5 +1,5 @@
 ---
-title: ":focus"
+title: "`:focus`"
 cover:
   desktop: 'images/covers/desktop.png'
   alt: 'Девушка с ноутбуком, дедушка с клавиатурой, парень с ноутбуком'

--- a/css/font-display/index.md
+++ b/css/font-display/index.md
@@ -1,5 +1,5 @@
 ---
-title: "font-display"
+title: "`font-display`"
 authors:
   - ezhkov
 keywords:

--- a/css/font-face/index.md
+++ b/css/font-face/index.md
@@ -1,5 +1,5 @@
 ---
-title: "@font-face"
+title: "`@font-face`"
 authors:
   - solarrust
 editors:

--- a/css/font-family/index.md
+++ b/css/font-family/index.md
@@ -1,5 +1,5 @@
 ---
-title: "font-family"
+title: "`font-family`"
 authors:
   - grachev
 contributors:

--- a/css/font-feature-settings/index.md
+++ b/css/font-feature-settings/index.md
@@ -1,5 +1,5 @@
 ---
-title: "font-feature-settings"
+title: "`font-feature-settings`"
 description: ""
 authors:
   - doka-dog

--- a/css/font-kerning/index.md
+++ b/css/font-kerning/index.md
@@ -1,5 +1,5 @@
 ---
-title: "font-kerning"
+title: "`font-kerning`"
 description: ""
 authors:
   - doka-dog

--- a/css/font-size-adjust/index.md
+++ b/css/font-size-adjust/index.md
@@ -1,5 +1,5 @@
 ---
-title: "font-size-adjust"
+title: "`font-size-adjust`"
 description: ""
 authors:
   - doka-dog

--- a/css/font-size/index.md
+++ b/css/font-size/index.md
@@ -1,5 +1,5 @@
 ---
-title: "font-size"
+title: "`font-size`"
 authors:
   - grachev
 contributors:

--- a/css/font-smooth/index.md
+++ b/css/font-smooth/index.md
@@ -1,5 +1,5 @@
 ---
-title: "font-smooth"
+title: "`font-smooth`"
 authors:
   - solarrust
   - pepelsbey

--- a/css/font-stretch/index.md
+++ b/css/font-stretch/index.md
@@ -1,5 +1,5 @@
 ---
-title: "font-stretch"
+title: "`font-stretch`"
 description: ""
 authors:
   - doka-dog

--- a/css/font-style/index.md
+++ b/css/font-style/index.md
@@ -1,5 +1,5 @@
 ---
-title: "font-style"
+title: "`font-style`"
 authors:
   - grachev
 contributors:

--- a/css/font-variant-numeric/index.md
+++ b/css/font-variant-numeric/index.md
@@ -1,5 +1,5 @@
 ---
-title: "font-variant-numeric"
+title: "`font-variant-numeric`"
 description: ""
 authors:
   - doka-dog

--- a/css/font-variant/index.md
+++ b/css/font-variant/index.md
@@ -1,5 +1,5 @@
 ---
-title: "font-variant"
+title: "`font-variant`"
 description: ""
 authors:
   - doka-dog

--- a/css/font-weight/index.md
+++ b/css/font-weight/index.md
@@ -1,5 +1,5 @@
 ---
-title: "font-weight"
+title: "`font-weight`"
 authors:
   - grachev
 contributors:

--- a/css/font/index.md
+++ b/css/font/index.md
@@ -1,5 +1,5 @@
 ---
-title: "font"
+title: "`font`"
 description: ""
 authors:
   - doka-dog

--- a/css/gap/index.md
+++ b/css/gap/index.md
@@ -1,5 +1,5 @@
 ---
-title: "gap"
+title: "`gap`"
 authors:
   - solarrust
 keywords:

--- a/css/grid-area/index.md
+++ b/css/grid-area/index.md
@@ -1,5 +1,5 @@
 ---
-title: "grid-area"
+title: "`grid-area`"
 authors:
   - solarrust
 tags:

--- a/css/grid-auto-columns-rows/index.md
+++ b/css/grid-auto-columns-rows/index.md
@@ -1,5 +1,5 @@
 ---
-title: "grid-auto-columns, grid-auto-rows"
+title: "`grid-auto-columns`, `grid-auto-rows`"
 authors:
   - solarrust
 keywords:

--- a/css/grid-auto-flow/index.md
+++ b/css/grid-auto-flow/index.md
@@ -1,5 +1,5 @@
 ---
-title: "grid-auto-flow"
+title: "`grid-auto-flow`"
 authors:
   - solarrust
 keywords:

--- a/css/grid-column-row/index.md
+++ b/css/grid-column-row/index.md
@@ -1,5 +1,5 @@
 ---
-title: "grid-column, grid-row"
+title: "`grid-column`, `grid-row`"
 authors:
   - solarrust
 keywords:

--- a/css/grid-start-end/index.md
+++ b/css/grid-start-end/index.md
@@ -1,5 +1,5 @@
 ---
-title: "grid-column-start, grid-column-end, grid-row-start, grid-row-end"
+title: "`grid-column-start`, `grid-column-end`, `grid-row-start`, `grid-row-end`"
 authors:
   - solarrust
 keywords:

--- a/css/grid-template-areas/index.md
+++ b/css/grid-template-areas/index.md
@@ -1,5 +1,5 @@
 ---
-title: "grid-template-areas"
+title: "`grid-template-areas`"
 authors:
   - solarrust
 keywords:

--- a/css/grid-template-columns/index.md
+++ b/css/grid-template-columns/index.md
@@ -1,5 +1,5 @@
 ---
-title: "grid-template-columns"
+title: "`grid-template-columns`"
 authors:
   - solarrust
 keywords:

--- a/css/grid-template-rows/index.md
+++ b/css/grid-template-rows/index.md
@@ -1,5 +1,5 @@
 ---
-title: "grid-template-rows"
+title: "`grid-template-rows`"
 authors:
   - solarrust
 keywords:

--- a/css/grid-template/index.md
+++ b/css/grid-template/index.md
@@ -1,5 +1,5 @@
 ---
-title: "grid-template"
+title: "`grid-template`"
 authors:
   - solarrust
 keywords:

--- a/css/grid/index.md
+++ b/css/grid/index.md
@@ -1,5 +1,5 @@
 ---
-title: "grid"
+title: "`grid`"
 authors:
   - solarrust
 keywords:

--- a/css/has/index.md
+++ b/css/has/index.md
@@ -1,5 +1,5 @@
 ---
-title: ":has"
+title: "`:has`"
 authors:
   - realetive
 editors:

--- a/css/height/index.md
+++ b/css/height/index.md
@@ -1,5 +1,5 @@
 ---
-title: "height"
+title: "`height`"
 authors:
   - solarrust
 contributors:

--- a/css/hover/index.md
+++ b/css/hover/index.md
@@ -1,5 +1,5 @@
 ---
-title: ":hover"
+title: "`:hover`"
 authors:
   - solarrust
 contributors:

--- a/css/hyphens/index.md
+++ b/css/hyphens/index.md
@@ -1,5 +1,5 @@
 ---
-title: "hyphens"
+title: "`hyphens`"
 authors:
   - doka-dog
 keywords:

--- a/css/image-set/index.md
+++ b/css/image-set/index.md
@@ -1,5 +1,5 @@
 ---
-title: "image-set()"
+title: "`image-set()`"
 authors:
   - doka-dog
 keywords:

--- a/css/import/index.md
+++ b/css/import/index.md
@@ -1,5 +1,5 @@
 ---
-title: "@import"
+title: "`@import`"
 authors:
   - solarrust
 editors:

--- a/css/in-range-out-of-range/index.md
+++ b/css/in-range-out-of-range/index.md
@@ -1,5 +1,5 @@
 ---
-title: ":in-range и :out-of-range"
+title: "`:in-range` и `:out-of-range`"
 authors:
   - ezhkov
 editors:

--- a/css/invalid-valid/index.md
+++ b/css/invalid-valid/index.md
@@ -1,5 +1,5 @@
 ---
-title: ":invalid и :valid"
+title: "`:invalid` и `:valid`"
 authors:
   - ezhkov
 editors:

--- a/css/is/index.md
+++ b/css/is/index.md
@@ -1,5 +1,5 @@
 ---
-title: ":is()"
+title: "`:is()`"
 authors:
   - doka-dog
 keywords:

--- a/css/justify-content/index.md
+++ b/css/justify-content/index.md
@@ -1,5 +1,5 @@
 ---
-title: "justify-content"
+title: "`justify-content`"
 authors:
   - solarrust
 editors:

--- a/css/justify-items/index.md
+++ b/css/justify-items/index.md
@@ -1,5 +1,5 @@
 ---
-title: "justify-items"
+title: "`justify-items`"
 authors:
   - solarrust
 keywords:

--- a/css/justify-self/index.md
+++ b/css/justify-self/index.md
@@ -1,5 +1,5 @@
 ---
-title: "justify-self"
+title: "`justify-self`"
 authors:
   - solarrust
 keywords:

--- a/css/keyframes/index.md
+++ b/css/keyframes/index.md
@@ -1,5 +1,5 @@
 ---
-title: "@keyframes"
+title: "`@keyframes`"
 authors:
   - solarrust
 keywords:

--- a/css/letter-spacing/index.md
+++ b/css/letter-spacing/index.md
@@ -1,5 +1,5 @@
 ---
-title: "letter-spacing"
+title: "`letter-spacing`"
 authors:
   - grachev
 contributors:

--- a/css/line-height/index.md
+++ b/css/line-height/index.md
@@ -1,5 +1,5 @@
 ---
-title: "line-height"
+title: "`line-height`"
 authors:
   - grachev
 contributors:

--- a/css/linear-gradient/index.md
+++ b/css/linear-gradient/index.md
@@ -1,5 +1,5 @@
 ---
-title: "linear-gradient()"
+title: "`linear-gradient()`"
 authors:
   - ezhkov_d
 keywords:

--- a/css/link/index.md
+++ b/css/link/index.md
@@ -1,5 +1,5 @@
 ---
-title: ":link"
+title: "`:link`"
 authors:
   - realetive
 editors:

--- a/css/list-style-image/index.md
+++ b/css/list-style-image/index.md
@@ -1,5 +1,5 @@
 ---
-title: "list-style-image"
+title: "`list-style-image`"
 authors:
   - ezhkov
 contributors:

--- a/css/list-style-position/index.md
+++ b/css/list-style-position/index.md
@@ -1,5 +1,5 @@
 ---
-title: "list-style-position"
+title: "`list-style-position`"
 authors:
   - ezhkov
 contributors:

--- a/css/list-style-type/index.md
+++ b/css/list-style-type/index.md
@@ -1,5 +1,5 @@
 ---
-title: "list-style-type"
+title: "`list-style-type`"
 authors:
   - realetive
 contributors:

--- a/css/margin/index.md
+++ b/css/margin/index.md
@@ -1,5 +1,5 @@
 ---
-title: "margin"
+title: "`margin`"
 authors:
   - grachev
 contributors:

--- a/css/media/index.md
+++ b/css/media/index.md
@@ -1,5 +1,5 @@
 ---
-title: "@media"
+title: "`@media`"
 authors:
   - lenaryan
 keywords:

--- a/css/not/index.md
+++ b/css/not/index.md
@@ -1,5 +1,5 @@
 ---
-title: ":not"
+title: "`:not`"
 authors:
   - solarrust
 editors:

--- a/css/nth-of-type/index.md
+++ b/css/nth-of-type/index.md
@@ -1,5 +1,5 @@
 ---
-title: "Псевдоклассы группы type"
+title: "Псевдоклассы группы `type`"
 authors:
   - realetive
 contributors:

--- a/css/nth-of-type/index.md
+++ b/css/nth-of-type/index.md
@@ -1,5 +1,5 @@
 ---
-title: "Псевдоклассы группы `type`"
+title: "Псевдоклассы группы type"
 authors:
   - realetive
 contributors:

--- a/css/object-fit/index.md
+++ b/css/object-fit/index.md
@@ -1,5 +1,5 @@
 ---
-title: "object-fit"
+title: "`object-fit`"
 authors:
   - solarrust
 contributors:

--- a/css/object-position/index.md
+++ b/css/object-position/index.md
@@ -1,5 +1,5 @@
 ---
-title: "object-position"
+title: "`object-position`"
 authors:
   - lenaryan
 keywords:

--- a/css/opacity/index.md
+++ b/css/opacity/index.md
@@ -1,5 +1,5 @@
 ---
-title: "opacity"
+title: "`opacity`"
 authors:
   - solarrust
 keywords:

--- a/css/order/index.md
+++ b/css/order/index.md
@@ -1,5 +1,5 @@
 ---
-title: "order"
+title: "`order`"
 authors:
   - solarrust
 editors:

--- a/css/outline/index.md
+++ b/css/outline/index.md
@@ -1,5 +1,5 @@
 ---
-title: "outline"
+title: "`outline`"
 authors:
   - solarrust
 keywords:

--- a/css/overflow/index.md
+++ b/css/overflow/index.md
@@ -1,5 +1,5 @@
 ---
-title: "overflow"
+title: "`overflow`"
 authors:
   - realetive
 tags:

--- a/css/padding/index.md
+++ b/css/padding/index.md
@@ -1,5 +1,5 @@
 ---
-title: "padding"
+title: "`padding`"
 authors:
   - solarrust
 contributors:

--- a/css/place-items/index.md
+++ b/css/place-items/index.md
@@ -1,5 +1,5 @@
 ---
-title: "place-items"
+title: "`place-items`"
 authors:
   - solarrust
 keywords:

--- a/css/place-self/index.md
+++ b/css/place-self/index.md
@@ -1,5 +1,5 @@
 ---
-title: "place-self"
+title: "`place-self`"
 authors:
   - solarrust
 keywords:

--- a/css/placeholder-shown/index.md
+++ b/css/placeholder-shown/index.md
@@ -1,5 +1,5 @@
 ---
-title: ":placeholder-shown"
+title: "`:placeholder-shown`"
 authors:
   - ezhkov
 editors:

--- a/css/placeholder/index.md
+++ b/css/placeholder/index.md
@@ -1,5 +1,5 @@
 ---
-title: "::placeholder"
+title: "`::placeholder`"
 authors:
   - ezhkov
 contributors:

--- a/css/position/index.md
+++ b/css/position/index.md
@@ -1,5 +1,5 @@
 ---
-title: "position"
+title: "`position`"
 authors:
   - ezhkov
 editors:

--- a/css/quotes/index.md
+++ b/css/quotes/index.md
@@ -1,5 +1,5 @@
 ---
-title: "quotes"
+title: "`quotes`"
 authors:
   - solarrust
 contributors:

--- a/css/radial-gradient/index.md
+++ b/css/radial-gradient/index.md
@@ -1,5 +1,5 @@
 ---
-title: "radial-gradient()"
+title: "`radial-gradient()`"
 authors:
   - ezhkov_d
 editors:

--- a/css/rem-em/index.md
+++ b/css/rem-em/index.md
@@ -1,5 +1,5 @@
 ---
-title: "rem, em"
+title: "`rem`, `em`"
 authors:
   - realetive
 keywords:

--- a/css/required/index.md
+++ b/css/required/index.md
@@ -1,5 +1,5 @@
 ---
-title: ":required"
+title: "`:required`"
 authors:
   - ezhkov
 editors:

--- a/css/root/index.md
+++ b/css/root/index.md
@@ -1,5 +1,5 @@
 ---
-title: ":root"
+title: "`:root`"
 authors:
   - lenaryan
 editors:

--- a/css/stroke/index.md
+++ b/css/stroke/index.md
@@ -1,5 +1,5 @@
 ---
-title: "stroke"
+title: "`stroke`"
 authors:
   - realetive
 keywords:

--- a/css/supports/index.md
+++ b/css/supports/index.md
@@ -1,5 +1,5 @@
 ---
-title: "@supports"
+title: "`@supports`"
 description: ""
 authors:
   - doka-dog

--- a/css/text-align/index.md
+++ b/css/text-align/index.md
@@ -1,5 +1,5 @@
 ---
-title: "text-align"
+title: "`text-align`"
 authors:
   - solarrust
 contributors:

--- a/css/text-decoration-color/index.md
+++ b/css/text-decoration-color/index.md
@@ -1,5 +1,5 @@
 ---
-title: "text-decoration-color"
+title: "`text-decoration-color`"
 authors:
   - doka-dog
 keywords:

--- a/css/text-decoration-line/index.md
+++ b/css/text-decoration-line/index.md
@@ -1,5 +1,5 @@
 ---
-title: "text-decoration-line"
+title: "`text-decoration-line`"
 authors:
   - doka-dog
 keywords:

--- a/css/text-decoration-style/index.md
+++ b/css/text-decoration-style/index.md
@@ -1,5 +1,5 @@
 ---
-title: "text-decoration-style"
+title: "`text-decoration-style`"
 authors:
   - doka-dog
 keywords:

--- a/css/text-decoration-thickness/index.md
+++ b/css/text-decoration-thickness/index.md
@@ -1,5 +1,5 @@
 ---
-title: "text-decoration-thickness"
+title: "`text-decoration-thickness`"
 authors:
   - doka-dog
 keywords:

--- a/css/text-decoration/index.md
+++ b/css/text-decoration/index.md
@@ -1,5 +1,5 @@
 ---
-title: "text-decoration"
+title: "`text-decoration`"
 authors:
   - solarrust
 contributors:

--- a/css/text-indent/index.md
+++ b/css/text-indent/index.md
@@ -1,5 +1,5 @@
 ---
-title: "text-indent"
+title: "`text-indent`"
 authors:
   - doka-dog
 keywords:

--- a/css/text-justify/index.md
+++ b/css/text-justify/index.md
@@ -1,5 +1,5 @@
 ---
-title: "text-justify"
+title: "`text-justify`"
 authors:
   - doka-dog
 keywords:

--- a/css/text-orientation/index.md
+++ b/css/text-orientation/index.md
@@ -1,5 +1,5 @@
 ---
-title: "text-orientation"
+title: "`text-orientation`"
 authors:
   - doka-dog
 keywords:

--- a/css/text-rendering/index.md
+++ b/css/text-rendering/index.md
@@ -1,5 +1,5 @@
 ---
-title: "text-rendering"
+title: "`text-rendering`"
 authors:
   - ezhkov
 keywords:

--- a/css/text-shadow/index.md
+++ b/css/text-shadow/index.md
@@ -1,5 +1,5 @@
 ---
-title: "text-shadow"
+title: "`text-shadow`"
 authors:
   - solarrust
 contributors:

--- a/css/text-size-adjust/index.md
+++ b/css/text-size-adjust/index.md
@@ -1,5 +1,5 @@
 ---
-title: "text-size-adjust"
+title: "`text-size-adjust`"
 authors:
   - doka-dog
 keywords:

--- a/css/text-transform/index.md
+++ b/css/text-transform/index.md
@@ -1,5 +1,5 @@
 ---
-title: "text-transform"
+title: "`text-transform`"
 authors:
   - solarrust
 contributors:

--- a/css/text-underline-offset/index.md
+++ b/css/text-underline-offset/index.md
@@ -1,5 +1,5 @@
 ---
-title: "text-underline-offset"
+title: "`text-underline-offset`"
 authors:
   - doka-dog
 keywords:

--- a/css/text-underline-position/index.md
+++ b/css/text-underline-position/index.md
@@ -1,5 +1,5 @@
 ---
-title: "text-underline-position"
+title: "`text-underline-position`"
 authors:
   - doka-dog
 keywords:

--- a/css/transform-origin/index.md
+++ b/css/transform-origin/index.md
@@ -1,5 +1,5 @@
 ---
-title: "transform-origin"
+title: "`transform-origin`"
 authors:
   - ezhkov
 keywords:

--- a/css/transform-style/index.md
+++ b/css/transform-style/index.md
@@ -1,5 +1,5 @@
 ---
-title: "transform-style"
+title: "`transform-style`"
 authors:
   - ezhkov
 keywords:

--- a/css/transform/index.md
+++ b/css/transform/index.md
@@ -1,5 +1,5 @@
 ---
-title: "transform"
+title: "`transform`"
 authors:
   - ezhkov
 contributors:

--- a/css/transition-delay/index.md
+++ b/css/transition-delay/index.md
@@ -1,5 +1,5 @@
 ---
-title: "transition-delay"
+title: "`transition-delay`"
 authors:
   - ezhkov
 keywords:

--- a/css/transition-duration/index.md
+++ b/css/transition-duration/index.md
@@ -1,5 +1,5 @@
 ---
-title: "transition-duration"
+title: "`transition-duration`"
 authors:
   - ezhkov
 keywords:

--- a/css/transition-property/index.md
+++ b/css/transition-property/index.md
@@ -1,5 +1,5 @@
 ---
-title: "transition-property"
+title: "`transition-property`"
 authors:
   - ezhkov
 keywords:

--- a/css/transition-timing-function/index.md
+++ b/css/transition-timing-function/index.md
@@ -1,5 +1,5 @@
 ---
-title: "transition-timing-function"
+title: "`transition-timing-function`"
 authors:
   - ezhkov
 keywords:

--- a/css/transition/index.md
+++ b/css/transition/index.md
@@ -1,5 +1,5 @@
 ---
-title: "transition"
+title: "`transition`"
 authors:
   - ezhkov
 contributors:

--- a/css/vertical-align/index.md
+++ b/css/vertical-align/index.md
@@ -1,5 +1,5 @@
 ---
-title: "vertical-align"
+title: "`vertical-align`"
 authors:
   - solarrust
 contributors:

--- a/css/visibility/index.md
+++ b/css/visibility/index.md
@@ -1,5 +1,5 @@
 ---
-title: "visibility"
+title: "`visibility`"
 authors:
   - solarrust
 contributors:

--- a/css/visited/index.md
+++ b/css/visited/index.md
@@ -1,5 +1,5 @@
 ---
-title: ":visited"
+title: "`:visited`"
 authors:
   - solarrust
 contributors:

--- a/css/vm-vh/index.md
+++ b/css/vm-vh/index.md
@@ -1,5 +1,5 @@
 ---
-title: "vm, vh, vmin, vmax"
+title: "`vm`, `vh`, `vmin`, `vmax`"
 authors:
   - ezhkov
 keywords:

--- a/css/white-space/index.md
+++ b/css/white-space/index.md
@@ -1,5 +1,5 @@
 ---
-title: "white-space"
+title: "`white-space`"
 authors:
   - ezhkov
 keywords:

--- a/css/width/index.md
+++ b/css/width/index.md
@@ -1,5 +1,5 @@
 ---
-title: "width"
+title: "`width`"
 authors:
   - solarrust
 contributors:

--- a/css/word-break/index.md
+++ b/css/word-break/index.md
@@ -1,5 +1,5 @@
 ---
-title: "word-break"
+title: "`word-break`"
 authors:
   - doka-dog
 keywords:

--- a/css/word-spacing/index.md
+++ b/css/word-spacing/index.md
@@ -1,5 +1,5 @@
 ---
-title: "word-spacing"
+title: "`word-spacing`"
 authors:
   - doka-dog
 keywords:

--- a/css/word-wrap/index.md
+++ b/css/word-wrap/index.md
@@ -1,5 +1,5 @@
 ---
-title: "word-wrap"
+title: "`word-wrap`"
 authors:
   - doka-dog
 keywords:

--- a/css/writing-mode/index.md
+++ b/css/writing-mode/index.md
@@ -1,5 +1,5 @@
 ---
-title: "writing-mode"
+title: "`writing-mode`"
 authors:
   - doka-dog
 keywords:

--- a/css/z-index/index.md
+++ b/css/z-index/index.md
@@ -1,5 +1,5 @@
 ---
-title: "z-index"
+title: "`z-index`"
 authors:
   - solarrust
 contributors:


### PR DESCRIPTION
Стоит добавить бэктики везде, где в заголовке указан код

было:

```njk
title: "flex"
```

стало

```njk
title: "`flex`
```

Необходимо для обработки кода после сливания [PR#349 из платформы](https://github.com/doka-guide/platform/pull/349)