### PR TITLE
Расставляет бэктики для кода в заголовках JS

### DIFF
--- a/js/alert/index.md
+++ b/js/alert/index.md
@@ -1,5 +1,5 @@
 ---
-title: "alert()"
+title: "`alert()`"
 cover:
   desktop: 'images/covers/desktop.svg'
   mobile: 'images/covers/mobile.svg'

--- a/js/array-every/index.md
+++ b/js/array-every/index.md
@@ -1,5 +1,5 @@
 ---
-title: "Array.every"
+title: "`Array.every`"
 authors:
   - windrushfarer
 editors:

--- a/js/array-filter/index.md
+++ b/js/array-filter/index.md
@@ -1,5 +1,5 @@
 ---
-title: "Array.filter"
+title: "`Array.filter`"
 authors:
   - windrushfarer
 contributors:

--- a/js/array-find/index.md
+++ b/js/array-find/index.md
@@ -1,5 +1,5 @@
 ---
-title: "Array.find"
+title: "`Array.find`"
 authors:
   - KognitivnayaBuena
 editors:

--- a/js/array-foreach/index.md
+++ b/js/array-foreach/index.md
@@ -1,5 +1,5 @@
 ---
-title: "Array.forEach"
+title: "`Array.forEach`"
 authors:
   - windrushfarer
 contributors:

--- a/js/array-from/index.md
+++ b/js/array-from/index.md
@@ -1,5 +1,5 @@
 ---
-title: "Array.from()"
+title: "`Array.from()`"
 description: "Функция создаёт новый массив на основе итерируемого или массивоподобного объекта"
 authors:
   - nlopin

--- a/js/array-length/index.md
+++ b/js/array-length/index.md
@@ -1,5 +1,5 @@
 ---
-title: ".length"
+title: "`.length`"
 description: "Свойство, которое возвращает количество элементов в массиве."
 authors:
   - nlopin

--- a/js/array-map/index.md
+++ b/js/array-map/index.md
@@ -1,5 +1,5 @@
 ---
-title: "Array.map"
+title: "`Array.map`"
 authors:
   - windrushfarer
 contributors:

--- a/js/array-reduce/index.md
+++ b/js/array-reduce/index.md
@@ -1,5 +1,5 @@
 ---
-title: "Array.reduce"
+title: "`Array.reduce`"
 authors:
   - windrushfarer
 keywords:

--- a/js/array-some/index.md
+++ b/js/array-some/index.md
@@ -1,5 +1,5 @@
 ---
-title: "Array.some"
+title: "`Array.some`"
 authors:
   - windrushfarer
 contributors:

--- a/js/async-await/index.md
+++ b/js/async-await/index.md
@@ -1,5 +1,5 @@
 ---
-title: "async/await"
+title: "`async/await`"
 authors:
   - nlopin
 keywords:

--- a/js/boolean/index.md
+++ b/js/boolean/index.md
@@ -1,5 +1,5 @@
 ---
-title: "Boolean"
+title: "`Boolean`"
 authors:
   - bespoyasov
 contributors:

--- a/js/clearinterval/index.md
+++ b/js/clearinterval/index.md
@@ -1,5 +1,5 @@
 ---
-title: "clearInterval"
+title: "`clearInterval`"
 description: "Отменяет регулярное выполнение функции, установленное вызовом setInterval"
 authors:
   - nlopin

--- a/js/cleartimeout/index.md
+++ b/js/cleartimeout/index.md
@@ -1,5 +1,5 @@
 ---
-title: "Element.clearTimeout"
+title: "`Element.clearTimeout`"
 authors:
   - Windrushfarer
 keywords:

--- a/js/confirm/index.md
+++ b/js/confirm/index.md
@@ -1,5 +1,5 @@
 ---
-title: "confirm()"
+title: "`confirm()`"
 authors:
   - vindi-r
 contributors:

--- a/js/console-log/index.md
+++ b/js/console-log/index.md
@@ -1,5 +1,5 @@
 ---
-title: "console.log()"
+title: "`console.log()`"
 authors:
   - vindi-r
 contributors:

--- a/js/const/index.md
+++ b/js/const/index.md
@@ -1,5 +1,5 @@
 ---
-title: "const"
+title: "`const`"
 authors:
   - nlopin
 contributors:

--- a/js/element-addeventlistener/index.md
+++ b/js/element-addeventlistener/index.md
@@ -1,5 +1,5 @@
 ---
-title: "Element.addEventListener()"
+title: "`Element.addEventListener()`"
 authors:
   - vindi-r
 contributors:

--- a/js/element-blur/index.md
+++ b/js/element-blur/index.md
@@ -1,5 +1,5 @@
 ---
-title: ".blur()"
+title: "`.blur()`"
 description: "Снимает фокус с DOM-элемента, на котором вызван"
 authors:
   - windrushfarer

--- a/js/element-classlist/index.md
+++ b/js/element-classlist/index.md
@@ -1,5 +1,5 @@
 ---
-title: "Element.classList"
+title: "`Element.classList`"
 authors:
   - windrushfarer
 contributors:

--- a/js/element-click/index.md
+++ b/js/element-click/index.md
@@ -1,5 +1,5 @@
 ---
-title: "Element.click"
+title: "`Element.click`"
 authors:
   - nlopin
 tags:

--- a/js/element-dataset/index.md
+++ b/js/element-dataset/index.md
@@ -1,5 +1,5 @@
 ---
-title: "Element.dataset"
+title: "`Element.dataset`"
 authors:
   - Windrushfarer
 keywords:

--- a/js/element-focus/index.md
+++ b/js/element-focus/index.md
@@ -1,5 +1,5 @@
 ---
-title: "Element.focus()"
+title: "`Element.focus()`"
 description: "Метод, который устанавливает фокус на DOM-элемент, на котором вызван."
 authors:
   - nlopin

--- a/js/element-getattribute/index.md
+++ b/js/element-getattribute/index.md
@@ -1,5 +1,5 @@
 ---
-title: "Element.getAttribute"
+title: "`Element.getAttribute`"
 authors:
   - Windrushfarer
 keywords:

--- a/js/element-hidden/index.md
+++ b/js/element-hidden/index.md
@@ -1,5 +1,5 @@
 ---
-title: "Element.hidden"
+title: "`Element.hidden`"
 description: "Свойство .hidden у DOM-элементов позволяет узнать или изменить значение HTML-атрибута hidden"
 authors:
   - windrushfarer

--- a/js/element-innerhtml/index.md
+++ b/js/element-innerhtml/index.md
@@ -1,5 +1,5 @@
 ---
-title: "Element.innerHTML"
+title: "`Element.innerHTML`"
 authors:
   - Windrushfarer
 tags:

--- a/js/element-innertext/index.md
+++ b/js/element-innertext/index.md
@@ -1,5 +1,5 @@
 ---
-title: "Element.innerText"
+title: "`Element.innerText`"
 authors:
   - Windrushfarer
 tags:

--- a/js/element-keydown-keyup/index.md
+++ b/js/element-keydown-keyup/index.md
@@ -1,5 +1,5 @@
 ---
-title: "Element.Keydown/Keyup"
+title: "`Element.Keydown/Keyup`"
 authors:
   - stegur
 contributors:

--- a/js/element-mouseout/index.md
+++ b/js/element-mouseout/index.md
@@ -1,5 +1,5 @@
 ---
-title: "Element.mouseout"
+title: "`Element.mouseout`"
 authors:
   - nlopin
 contributors:

--- a/js/element-mouseover/index.md
+++ b/js/element-mouseover/index.md
@@ -1,5 +1,5 @@
 ---
-title: "Element.mouseover"
+title: "`Element.mouseover`"
 authors:
   - nlopin
 contributors:

--- a/js/element-outerhtml/index.md
+++ b/js/element-outerhtml/index.md
@@ -1,5 +1,5 @@
 ---
-title: "Element.oute/"
+title: "`Element.outerHTML`"
 authors:
   - windrushfarer
 tags:

--- a/js/element-removeeventlistener/index.md
+++ b/js/element-removeeventlistener/index.md
@@ -1,5 +1,5 @@
 ---
-title: "Element.removeEventListener()"
+title: "`Element.removeEventListener()`"
 authors:
   - vindi-r
 contributors:

--- a/js/element-scroll-scrollintoview/index.md
+++ b/js/element-scroll-scrollintoview/index.md
@@ -1,5 +1,5 @@
 ---
-title: "Element.scroll/scrollIntoView"
+title: "`Element.scroll/scrollIntoView`"
 authors:
   - vindi-r
 contributors:

--- a/js/element-scroll-scrollto/index.md
+++ b/js/element-scroll-scrollto/index.md
@@ -1,5 +1,5 @@
 ---
-title: "Element.scroll/scrollTo"
+title: "`Element.scroll/scrollTo`"
 authors:
   - vindi-r
 tags:

--- a/js/element-scroll-wheel/index.md
+++ b/js/element-scroll-wheel/index.md
@@ -1,5 +1,5 @@
 ---
-title: "Element.scroll/wheel"
+title: "`Element.scroll/wheel`"
 authors:
   - nlopin
 contributors:

--- a/js/element-style/index.md
+++ b/js/element-style/index.md
@@ -1,5 +1,5 @@
 ---
-title: "Element.style"
+title: "`Element.style`"
 authors:
   - bespoyasov
 tags:

--- a/js/element-textcontent/index.md
+++ b/js/element-textcontent/index.md
@@ -1,5 +1,5 @@
 ---
-title: "Element.textContent"
+title: "`Element.textContent`"
 authors:
   - Windrushfarer
 tags:

--- a/js/element-touch/index.md
+++ b/js/element-touch/index.md
@@ -1,5 +1,5 @@
 ---
-title: "Element.touch"
+title: "`Element.touch`"
 authors:
   - windrushfarer
 keywords:

--- a/js/event-load-and-domcontentloaded/index.md
+++ b/js/event-load-and-domcontentloaded/index.md
@@ -1,5 +1,5 @@
 ---
-title: "Событие load и DOMContentLoaded"
+title: "Событие `load` и `DOMContentLoaded`"
 authors:
   - nlopin
 contributors:

--- a/js/fetch/index.md
+++ b/js/fetch/index.md
@@ -1,5 +1,5 @@
 ---
-title: "fetch"
+title: "`fetch`"
 authors:
   - windrushfarer
 keywords:

--- a/js/for/index.md
+++ b/js/for/index.md
@@ -1,5 +1,5 @@
 ---
-title: "for()"
+title: "`for()`"
 authors:
   - vindi-r
 keywords:

--- a/js/function-context/index.md
+++ b/js/function-context/index.md
@@ -1,5 +1,5 @@
 ---
-title: "Контекст выполнения функций, this"
+title: "Контекст выполнения функций, `this`"
 authors:
   - bespoyasov
 keywords:

--- a/js/function/index.md
+++ b/js/function/index.md
@@ -1,5 +1,5 @@
 ---
-title: "function()"
+title: "`function()`"
 authors:
   - vindi-r
 keywords:

--- a/js/getelementbyid/index.md
+++ b/js/getelementbyid/index.md
@@ -1,5 +1,5 @@
 ---
-title: "getElementById()"
+title: "`getElementById()`"
 authors:
   - nlopin
 tags:

--- a/js/getelementsbyclassname/index.md
+++ b/js/getelementsbyclassname/index.md
@@ -1,5 +1,5 @@
 ---
-title: "getElementsByClassName()"
+title: "`getElementsByClassName()`"
 authors:
   - nlopin
 tags:

--- a/js/getelementsbytagname/index.md
+++ b/js/getelementsbytagname/index.md
@@ -1,5 +1,5 @@
 ---
-title: "getElementsByTagName()"
+title: "`getElementsByTagName()`"
 authors:
   - nlopin
 tags:

--- a/js/htmlcollection-and-nodelist/index.md
+++ b/js/htmlcollection-and-nodelist/index.md
@@ -1,5 +1,5 @@
 ---
-title: "HTMLCollection и NodeList"
+title: "`HTMLCollection` и `NodeList`"
 authors:
   - nlopin
 tags:

--- a/js/if-else/index.md
+++ b/js/if-else/index.md
@@ -1,5 +1,5 @@
 ---
-title: "if...else"
+title: "`if`...`else`"
 authors:
   - nlopin
 keywords:

--- a/js/includes/index.md
+++ b/js/includes/index.md
@@ -1,5 +1,5 @@
 ---
-title: "includes"
+title: "`includes`"
 authors:
   - nlopin
 tags:

--- a/js/index-of/index.md
+++ b/js/index-of/index.md
@@ -1,5 +1,5 @@
 ---
-title: "indexOf()"
+title: "`indexOf()`"
 authors:
   - nlopin
 tags:

--- a/js/local-storage/index.md
+++ b/js/local-storage/index.md
@@ -1,5 +1,5 @@
 ---
-title: "localStorage"
+title: "`localStorage`"
 authors:
   - akellbl4
 keywords:

--- a/js/math-floor/index.md
+++ b/js/math-floor/index.md
@@ -1,5 +1,5 @@
 ---
-title: "Math.floor()"
+title: "`Math.floor()`"
 authors:
   - nlopin
 tags:

--- a/js/math-random/index.md
+++ b/js/math-random/index.md
@@ -1,5 +1,5 @@
 ---
-title: "Math.random()"
+title: "`Math.random()`"
 authors:
   - nlopin
 tags:

--- a/js/math/index.md
+++ b/js/math/index.md
@@ -1,5 +1,5 @@
 ---
-title: "Math"
+title: "`Math`"
 authors:
   - vindi-r
 tags:

--- a/js/modules/index.md
+++ b/js/modules/index.md
@@ -1,5 +1,5 @@
 ---
-title: "Модули, import/export"
+title: "Модули, `import`/`export`"
 authors:
   - bespoyasov
 keywords:

--- a/js/null-undefined/index.md
+++ b/js/null-undefined/index.md
@@ -1,5 +1,5 @@
 ---
-title: "Null и undefined"
+title: "`Null` и `undefined`"
 authors:
   - nlopin
 keywords:

--- a/js/number-is-nan/index.md
+++ b/js/number-is-nan/index.md
@@ -1,5 +1,5 @@
 ---
-title: "Number.isNaN()"
+title: "`Number.isNaN()`"
 authors:
   - vindi-r
 tags:

--- a/js/number-isfinite/index.md
+++ b/js/number-isfinite/index.md
@@ -1,5 +1,5 @@
 ---
-title: "Number.isFinite"
+title: "`Number.isFinite`"
 authors:
   - windrushfarer
 tags:

--- a/js/number-wrapper/index.md
+++ b/js/number-wrapper/index.md
@@ -1,5 +1,5 @@
 ---
-title: "Number"
+title: "`Number`"
 authors:
   - nlopin
 keywords:

--- a/js/promise-catch/index.md
+++ b/js/promise-catch/index.md
@@ -1,5 +1,5 @@
 ---
-title: "Promise. Метод catch"
+title: "`Promise`. Метод `catch`"
 authors:
   - nlopin
 keywords:

--- a/js/promise-finally/index.md
+++ b/js/promise-finally/index.md
@@ -1,5 +1,5 @@
 ---
-title: "Promise. Метод finally"
+title: "`Promise`. Метод `finally`"
 authors:
   - nlopin
 keywords:

--- a/js/promise-then/index.md
+++ b/js/promise-then/index.md
@@ -1,5 +1,5 @@
 ---
-title: "Promise. Метод then"
+title: "`Promise`. Метод `then`"
 authors:
   - nlopin
 keywords:

--- a/js/promise/index.md
+++ b/js/promise/index.md
@@ -1,5 +1,5 @@
 ---
-title: "Promise"
+title: "`Promise`"
 cover:
   desktop: 'images/covers/desktop.png'
   alt: 'Две руки держат друг-друга мизинчиками и жесте "мирись-мирись-мирись"'

--- a/js/prompt/index.md
+++ b/js/prompt/index.md
@@ -1,5 +1,5 @@
 ---
-title: "prompt()"
+title: "`prompt()`"
 authors:
   - vindi-r
 tags:

--- a/js/query-selector-all/index.md
+++ b/js/query-selector-all/index.md
@@ -1,5 +1,5 @@
 ---
-title: "querySelectorAll"
+title: "`querySelectorAll`"
 authors:
   - nlopin
 keywords:

--- a/js/query-selector/index.md
+++ b/js/query-selector/index.md
@@ -1,5 +1,5 @@
 ---
-title: "querySelector"
+title: "`querySelector`"
 authors:
   - nlopin
 keywords:

--- a/js/return/index.md
+++ b/js/return/index.md
@@ -1,5 +1,5 @@
 ---
-title: "return"
+title: "`return`"
 authors:
   - vindi-r
 contributors:

--- a/js/session-storage/index.md
+++ b/js/session-storage/index.md
@@ -1,5 +1,5 @@
 ---
-title: "sessionStorage"
+title: "`sessionStorage`"
 authors:
   - akellbl4
 keywords:

--- a/js/set-add/index.md
+++ b/js/set-add/index.md
@@ -1,5 +1,5 @@
 ---
-title: ".add()"
+title: "`.add()`"
 description: "Добавляет значение в коллекцию Set"
 authors:
   - nlopin

--- a/js/set-clear/index.md
+++ b/js/set-clear/index.md
@@ -1,5 +1,5 @@
 ---
-title: ".clear"
+title: "`.clear`"
 description: "Удаляет все значения из коллекции Set"
 authors:
   - nlopin

--- a/js/set-delete/index.md
+++ b/js/set-delete/index.md
@@ -1,5 +1,5 @@
 ---
-title: ".delete()"
+title: "`.delete()`"
 description: "Удаляет значение из коллекции Set"
 authors:
   - nlopin

--- a/js/set-entries/index.md
+++ b/js/set-entries/index.md
@@ -1,5 +1,5 @@
 ---
-title: ".entries()"
+title: "`.entries()`"
 description: "Метод возвращает итератор пар [значение, значение] коллекции Set"
 authors:
   - nlopin

--- a/js/set-foreach/index.md
+++ b/js/set-foreach/index.md
@@ -1,5 +1,5 @@
 ---
-title: ".forEach()"
+title: "`.forEach()`"
 description: "Метод используется для обхода элементов коллекции Set"
 authors:
   - nlopin

--- a/js/set-has/index.md
+++ b/js/set-has/index.md
@@ -1,5 +1,5 @@
 ---
-title: ".has()"
+title: "`.has()`"
 description: "Метод проверяет наличие значения в коллекции Set"
 authors:
   - nlopin

--- a/js/set-keys/index.md
+++ b/js/set-keys/index.md
@@ -1,5 +1,5 @@
 ---
-title: ".keys()"
+title: "`.keys()`"
 description: "Возвращает итератор для обхода значений коллекции Set"
 authors:
   - nlopin

--- a/js/set-size/index.md
+++ b/js/set-size/index.md
@@ -1,5 +1,5 @@
 ---
-title: ".size"
+title: "`.size`"
 description: "Свойство коллекции Set, содержит количество значений в коллекции"
 authors:
   - nlopin

--- a/js/set-values/index.md
+++ b/js/set-values/index.md
@@ -1,5 +1,5 @@
 ---
-title: ".values()"
+title: "`.values()`"
 description: "Возвращает итератор для обхода значений коллекции Set"
 authors:
   - nlopin

--- a/js/set/index.md
+++ b/js/set/index.md
@@ -1,5 +1,5 @@
 ---
-title: "Set"
+title: "`Set`"
 description: "Коллекция для хранения уникальных значений"
 authors:
   - nlopin

--- a/js/setinterval/index.md
+++ b/js/setinterval/index.md
@@ -1,5 +1,5 @@
 ---
-title: "setInterval"
+title: "`setInterval`"
 description: "Регулярно запускает функцию через указанный промежуток времени"
 authors:
   - nlopin

--- a/js/settimeout/index.md
+++ b/js/settimeout/index.md
@@ -1,5 +1,5 @@
 ---
-title: "setTimeout"
+title: "`setTimeout`"
 description: "Отложенный вызов функции. Вызывает функцию через указанный промежуток времени"
 authors:
   - Windrushfarer

--- a/js/string-length/index.md
+++ b/js/string-length/index.md
@@ -1,5 +1,5 @@
 ---
-title: ".length"
+title: "`.length`"
 description: "Свойство возвращает количество символов в строке"
 authors:
   - nlopin

--- a/js/switch/index.md
+++ b/js/switch/index.md
@@ -1,5 +1,5 @@
 ---
-title: "switch"
+title: "`switch`"
 authors:
   - nlopin
 contributors:

--- a/js/try-catch/index.md
+++ b/js/try-catch/index.md
@@ -1,5 +1,5 @@
 ---
-title: "try...catch"
+title: "`try`...`catch`"
 cover:
   desktop: 'images/covers/desktop.svg'
   mobile: 'images/covers/mobile.svg'

--- a/js/urlsearchparams/index.md
+++ b/js/urlsearchparams/index.md
@@ -1,5 +1,5 @@
 ---
-title: "URLSearchParams"
+title: "`URLSearchParams`"
 authors:
   - akellbl4
 keywords:

--- a/js/use-strict/index.md
+++ b/js/use-strict/index.md
@@ -1,5 +1,5 @@
 ---
-title: "use strict"
+title: "`use strict`"
 authors:
   - windrushfarer
 tags:

--- a/js/var-let/index.md
+++ b/js/var-let/index.md
@@ -1,5 +1,5 @@
 ---
-title: "var/let"
+title: "`var`/`let`"
 authors:
   - vindi-r
 contributors:

--- a/js/while/index.md
+++ b/js/while/index.md
@@ -1,5 +1,5 @@
 ---
-title: "while"
+title: "`while`"
 authors:
   - nlopin
 contributors:

--- a/js/window-location/index.md
+++ b/js/window-location/index.md
@@ -1,5 +1,5 @@
 ---
-title: "window.location"
+title: "`window.location`"
 authors:
   - akellbl4
 tags:

--- a/js/window-print/index.md
+++ b/js/window-print/index.md
@@ -1,5 +1,5 @@
 ---
-title: "window.print()"
+title: "`window.print()`"
 description: "Открывает диалог печати текущей страницы"
 authors:
   - nlopin


### PR DESCRIPTION
Стоит добавить бэктики везде, где в заголовке указан код

было:

```njk
title: "use strict"
```

стало

```njk
title: "`use strict`"
```

Необходимо для обработки кода после сливания [PR#349 из платформы](https://github.com/doka-guide/platform/pull/349)