### PR TITLE
Исправляет фактическую ошибку в комментарии

### DIFF
--- a/js/if-else/index.md
+++ b/js/if-else/index.md
@@ -107,7 +107,7 @@ if (foundItems === 0) {
 }
 
 if (user.isAdmin) {
-  // сокращенная запись user.isAdmin === true
+  // сокращенная запись user.isAdmin == true
   console.log("Привет, админ!")
 } else {
   console.log("Привет, пользователь!")


### PR DESCRIPTION
Для произвольной переменной в условии сработает приведение типов, которое проверяет "truthiness", а не прямое соответствие значению "true"