### PR TITLE
Исправляет вырезание текста между блоками кода при формировании поискового индекса

### DIFF
--- a/.github/scripts/search-index.js
+++ b/.github/scripts/search-index.js
@@ -26,8 +26,8 @@ const patternsForEntities = {
 const commonReplacement = /([#]+ |:::|callout |```|\*{2,2}|\n|_|\!\[|\[|\]|\([.:/a-z]+\))/g
 
 const getEntitiesFromContent = (text, patterns) => {
-  text = text.replace(/---(.|\n)*---\n/g, '') // Вырезаем мету
-  text = text.replace(/```(.|\n)*```\n/g, '') // Вырезаем код
+  text = text.replace(/---(.|\n)*?---\n/g, '') // Вырезаем мету
+  text = text.replace(/```(.|\n)*?```\n/g, '') // Вырезаем код
   const output = {}
   for (const field in patterns) {
     let array = text.match(patterns[field])


### PR DESCRIPTION
Исправляет https://github.com/doka-guide/platform/issues/554

Проблема в жадном регулярном выражении, которое помимо блоков кода также вырезало и блоки текста между ними