### PR TITLE
Исправляет путь к картинке на странице border-radius

### DIFF
--- a/css/border-radius/demos/notification/index.html
+++ b/css/border-radius/demos/notification/index.html
@@ -21,7 +21,7 @@
       background-size: 55px;
       background-repeat: no-repeat;
       background-color: #000000;
-      background-image: url(../images/eyes.png);
+      background-image: url(../../images/eyes.png);
       cursor: pointer;
     }
 


### PR DESCRIPTION
На странице [/border-radius](https://doka.guide/css/border-radius/#alyona-batickaya) в [демо элементе notification](https://doka.guide/css/border-radius/demos/notification/) исправил путь к картинке eyes.png

### Было:
![image](https://user-images.githubusercontent.com/37771198/137325252-dc19e9b7-edb5-499d-b110-856ff54e5319.png)
### Стало:
![image](https://user-images.githubusercontent.com/37771198/137325315-5afaf22f-e925-4441-8954-347b58ffb5ce.png)



