### PR TITLE
Ширина блока демо на 100%

### DIFF
--- a/html/input/index.md
+++ b/html/input/index.md
@@ -159,4 +159,4 @@ tags:
 </form>
 ```
 
-<iframe title="Различные input" src="demos/inputs/" height="440"></iframe>
+<iframe title="Различные input" src="demos/inputs/" height="440" width="100%"></iframe>


### PR DESCRIPTION
Сделать ширину блока демо на всю ширину статьи, потому что сейчас она имеет дефолтные 300 пикселей ширины, а внутренний контет фрейма имеет ширину 800px.
<img width="1665" alt="Снимок экрана 2021-10-15 в 21 49 42" src="https://user-images.githubusercontent.com/15684266/137538715-b9eabe7b-43c6-4e1a-9492-62b2f722def9.png">
<img width="1665" alt="Снимок экрана 2021-10-15 в 21 50 04" src="https://user-images.githubusercontent.com/15684266/137538826-4c3fdfbe-7f5f-43b6-98b3-33cb2ed045f9.png">


