### PR TITLE
Удаляет информацию про атрибут type в `<style>`

### DIFF
--- a/html/style/index.md
+++ b/html/style/index.md
@@ -44,7 +44,7 @@ tags:
 ```html
 <head>
   <style>
-    ...;
+    /* Стили */
   </style>
 </head>
 ```


### PR DESCRIPTION
Уже нет таких браузеров, которые не понимали бы HTML5, поэтому указывать этот атрибут совершенно излишне.