### PR TITLE
Добавляет `user-select: none` для кнопки в статье box-shadow

### DIFF
--- a/css/box-shadow/demos/skeuomorph/index.html
+++ b/css/box-shadow/demos/skeuomorph/index.html
@@ -30,6 +30,7 @@
       font-family: "Roboto", sans-serif;
       font-size: 20px;
       font-weight: 100;
+      user-select: none;
     }
 
     .button:active {
@@ -40,6 +41,6 @@
   </style>
 </head>
 <body>
-  <button class="button">Зажми</button>
+  <button class="button" type="button">Зажми</button>
 </body>
 </html>


### PR DESCRIPTION
При длительном таче (имитация `:active`) выделяется текст кнопки. `user-select: none;` решает эту проблему.

https://user-images.githubusercontent.com/2073959/138493900-c1edde9b-7e82-4854-9821-33a9a281a230.mp4


