### PR TITLE
`scroll-behavior`: добавляет `sandbox` на демку

### DIFF
--- a/css/scroll-behavior/index.md
+++ b/css/scroll-behavior/index.md
@@ -35,7 +35,7 @@ html {
 - `auto` — значение по умолчанию, мгновенная прокрутка;
 - `smooth` — плавная прокрутка.
 
-<iframe title="Варианты значений" src="demos/values/" height="200"></iframe>
+<iframe title="Варианты значений" src="demos/values/" height="200" sandbox></iframe>
 
 ## Подсказки
 


### PR DESCRIPTION
Сейчас демка влияет на страницу вокруг себя. Добавила атрибут `sandbox` чтобы так не было