### PR TITLE
Исправление высоты демо в css/stroke

### DIFF
--- a/css/stroke/demos/pattern/index.html
+++ b/css/stroke/demos/pattern/index.html
@@ -6,10 +6,14 @@
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <style>
     body {
+      margin: 0;
+      padding: 0;
       background-color: #18191c;
     }
 
     .module {
+      min-height: 150px;
+      height: 100vh;
       width: 100%;
       display: flex;
       justify-content: center;

--- a/css/stroke/index.md
+++ b/css/stroke/index.md
@@ -32,7 +32,7 @@ tags:
 }
 ```
 
-<iframe title="Заливка паттерном" src="demos/pattern/" height="200"></iframe>
+<iframe title="Заливка паттерном" src="demos/pattern/" height="166"></iframe>
 
 ## Подсказки
 


### PR DESCRIPTION
https://doka.guide/css/stroke

| До | После |
| -- | ----- |
|  ![Слишком большой отступ у демо снизу](https://user-images.githubusercontent.com/30597878/139338106-fd1b417a-a024-4ed0-9252-9f69e8469fba.png)| ![Демо с нормальным размером](https://user-images.githubusercontent.com/30597878/139338095-f0cb9b62-95ba-469e-a4c3-848c1f11b038.png) |

 