### PR TITLE
Исправляет падающий сортировщик словаря

### DIFF
--- a/.github/workflows/sort-dictionary.yml
+++ b/.github/workflows/sort-dictionary.yml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        node-version: 16
+        node-version: ['16']
     steps:
       - uses: actions/checkout@v2
         with:


### PR DESCRIPTION
[Судя по документации](https://github.com/actions/setup-node#matrix-testing), в `matrix` нужно всегда передавать массив