### PR TITLE
Update index.md

### DIFF
--- a/css/place-items/index.md
+++ b/css/place-items/index.md
@@ -24,7 +24,7 @@ tags:
 
 ## Как пишется
 
-Пишутся два доступных значения для свойств [`align-items`](/css/align-items) и [`justify-content`](/css/justify-content), разделённые слэшем.
+Пишутся два доступных значения для свойств [`align-items`](/css/align-items) и [`justify-items`](/css/justify-items), разделённые слэшем.
 
 ## Подсказки
 


### PR DESCRIPTION
Ошибка в описании. Описание из MDN: The CSS place-items shorthand property allows you to align items along both the block and inline directions at once (i.e. the align-items and justify-items properties) in a relevant layout system such as Grid or Flexbox.