### PR TITLE
Update index.md

### DIFF
--- a/css/grid-guide/index.md
+++ b/css/grid-guide/index.md
@@ -592,7 +592,7 @@ CSS Grid Layout ([спецификация](https://www.w3.org/TR/css-grid-1/)) 
 
 ### `place-items`
 
-Шорткат для указания значений сразу и для `align-items` и для `justify-content`. Указывать нужно именно в таком порядке.
+Шорткат для указания значений сразу и для `align-items` и для `justify-items`. Указывать нужно именно в таком порядке.
 
 ```css
 .container {


### PR DESCRIPTION
Ошибка в описании. Описание из MDN: The CSS place-items shorthand property allows you to align items along both the block and inline directions at once (i.e. the align-items and justify-items properties) in a relevant layout system such as Grid or Flexbox.