### PR TITLE
Исправит ошибку в примере на странице "Системы сборки"

### DIFF
--- a/tools/bundlers/index.md
+++ b/tools/bundlers/index.md
@@ -32,7 +32,7 @@ tags:
 
 ```bash
 npm init
-npm install parcel-bundler
+npm install parcel
 ```
 
 Теперь нужно создать HTML-файл, в котором описать относительные пути до JavaScript-файлов, и запустить бандлер. Он сделает всю остальную работу.
@@ -42,10 +42,11 @@ npm install parcel-bundler
 <html>
   <head>
     <title>Hello, bundler!</title>
-    <script src="./index.js"></script>
   </head>
   <body>
     <h1 id="title">Hello, bundler!</h1>
+
+    <script src="./index.js"></script>
   </body>
 </html>
 ```


### PR DESCRIPTION
Если подключать скрипт в шапку, то к моменту выполнения ещё негде будет менять текст. Перенёс скрипт в конец.

Заодно поправил название пакета, во втором Парселе это просто `parcel`.

p.s. Репорт не мой. Давали ссылку для доп.чтения, а прилетел фидбек. Но исправленный пример проверил: запустил в Парселе, всё заработало.