### PR TITLE
Улучшает проверку битых ссылок

### DIFF
--- a/.github/workflows/link-checker-all.yml
+++ b/.github/workflows/link-checker-all.yml
@@ -19,5 +19,5 @@ jobs:
         uses: ruzickap/action-my-broken-link-checker@v2.2.4
         with:
           url: https://doka.guide
-          cmd_params: --buffer-size=8192 --max-connections=10 --color=always --skip-tls-verification --timeout=20
+          cmd_params: --buffer-size=8192 --max-connections=10 --color=always --skip-tls-verification --timeout=20 --exclude=^https?:\/\/(localhost|127\.0\.0\.1|codepen.io)?(:[0-9]+)?(\/.*)?
           run_timeout: 600

--- a/.github/workflows/link-checker-all.yml
+++ b/.github/workflows/link-checker-all.yml
@@ -16,7 +16,7 @@ jobs:
           markdown: true
           linksToSkip: "https?://(localhost|codepen.io)?(:[0-9]+)?/.*"
       - name: Проверка ссылок в собранном сайте
-        uses: ruzickap/action-my-broken-link-checker@v2.2.4
+        uses: ruzickap/action-my-broken-link-checker@v2.2.5
         with:
           url: https://doka.guide
           cmd_params: --buffer-size=8192 --max-connections=10 --color=always --skip-tls-verification --timeout=20 --exclude=^https?:\/\/(localhost|127\.0\.0\.1|codepen.io)?(:[0-9]+)?(\/.*)?


### PR DESCRIPTION
На текущий момент при проверке битых ссылок в собранном сайте отсутствуют исключения в виде локалхоста ([пример](https://github.com/doka-guide/content/runs/4330856706?check_suite_focus=true#step:5:70)).

Данный ПР добавляет в исключения `localhost`, `127.0.0.1`, а также `codepen.io` - последний я взял из экшена рядом, который проверяет маркдаун файлы.

Исправляет doka-guide/platform#769

UPD:

Совместно с автором ruzickap/action-my-broken-link-checker/pull/52 исправили экшен проверки битых ссылок и теперь он корректно обрабатывает тег `<picture />` с множественными `srcSet` - из-за чего вывод не тонет в потоке нерелевантного мусора.

Дополнительно я предлагаю убрать полностью экшен `JustinBeckwith/linkinator-action@v1` - во-первых он в текущей конфигурации просто напросто не работает. Во-вторых, есть хорошо работающий (теперь) `ruzickap/action-my-broken-link-checker`