### PR TITLE
Перестраивает поисковый индекс для использования возможностей Algolia для подсветки результатов

### DIFF
--- a/.github/scripts/search-index.js
+++ b/.github/scripts/search-index.js
@@ -52,12 +52,24 @@ const getPractice = (path) => {
 }
 
 for (const fileName in commonSearch) {
+  const content = fs.readFileSync(fileName, {
+    encoding: 'utf8',
+    flag: 'r'
+  })
+
   if (new RegExp(stopCategories.join('|')).test(fileName)) {
     console.log(`Файл ${fileName} не будет добавлен в индекс.`)
   } else {
     const contentEntities = getEntitiesFromContent(content)
     const practicesEntities = getPractice(fileName.replace('index.md', 'practice/'))
+
     contentEntities.push(...practicesEntities)
+
+    const description = commonSearch[fileName].description
+    if (description) {
+      contentEntities.unshift(escape(description))
+    }
+
     const object = {
       objectID: fileName.replace('index.md', ''),
       title: escape(commonSearch[fileName].title || ''),

--- a/.github/scripts/search-index.js
+++ b/.github/scripts/search-index.js
@@ -2,6 +2,7 @@ const fs = require('fs')
 const algoliaClient = require('algoliasearch')
 const markdownIt = require('markdown-it')
 const { parseHTML } = require('linkedom')
+const { escape } = require('html-escaper')
 
 const md = markdownIt({
   html: true,
@@ -18,97 +19,52 @@ const stopCategories = [
   'pages'
 ]
 
-const patternsForEntities = {
-  // Заголовки второго уровня
-  header2: (document) => Array.from(document.querySelectorAll('h2')),
-
-  // Заголовки третьего уровня
-  header3: (document) => Array.from(document.querySelectorAll('h3')),
-
-  // Заголовки четвёртого уровня
-  header4: (document) => Array.from(document.querySelectorAll('h4')),
-
-  // Ссылки
-  links: (document) => Array.from(document.querySelectorAll('a')),
-
-  // Подписи к картинкам
-  images: (document) => Array.from(document.querySelectorAll('img'))
-    .map(img => img.getAttribute('alt')),
-
-  // Элементы списка
-  lists: (document) => Array.from(document.querySelectorAll('li')),
-
-  // Выделение полужирным шрифтом
-  bold: (document) => Array.from(document.querySelectorAll('b, strong')),
-
-  // Выделение наклонным шрифтом
-  italic: (document) => Array.from(document.querySelectorAll('i, em')),
-
-  // Блоки callout
-  callouts: (document) => Array.from(document.querySelectorAll('aside')),
-
-  // Параграфы
-  paragraphs: (document) => Array.from(document.querySelectorAll('p')),
-}
-
-
-const getEntitiesFromContent = (text, patterns) => {
+const getEntitiesFromContent = (text) => {
   text = text.replace(/---(.|\n)*?---\n/g, '') // Вырезаем мету
   const html = md.render(text)
   const { document } = parseHTML(html)
-  const output = {}
-  for (const field in patterns) {
-    output[field] = patterns[field](document)
-      .map(element => {
-        if (typeof element === 'string') {
-          return element
-        } else {
-          element.innerHTML = element.innerHTML
-            .replace('<code>', '`')
-            .replace('</code>', '`')
-          return element.textContent
-        }
-      })
-  }
+
+  const output = Array.from(document.children)
+    // на данный момент игнорируем поиск по коду
+    .filter(element => element.tagName.toLowerCase() !== 'pre')
+    .map(element => {
+      element.innerHTML = element.innerHTML
+        .replace('<code>', '`')
+        .replace('</code>', '`')
+      return escape(element.textContent)
+    })
+
   return output
 }
 
 const getPractice = (path) => {
-  const output = []
   if (fs.existsSync(path)) {
-    const files = fs.readdirSync(path, { encoding: 'utf8' } )
-    for (const practice of files) {
-      const fileName = path + practice
-      const content = fs.readFileSync(fileName, { encoding: 'utf8', flag: 'r' })
-      output.push(getEntitiesFromContent(content, patternsForEntities))
-    }
+    const practices = fs.readdirSync(path, { encoding: 'utf8' } )
+    return practices
+      .flatMap(practice => {
+        const fileName = path + practice
+        const content = fs.readFileSync(fileName, { encoding: 'utf8', flag: 'r' })
+        return getEntitiesFromContent(content)
+      })
   }
-  return output
+
+  return []
 }
 
 for (const fileName in commonSearch) {
-  const content = fs.readFileSync(fileName, { encoding: 'utf8', flag: 'r' })
   if (new RegExp(stopCategories.join('|')).test(fileName)) {
     console.log(`Файл ${fileName} не будет добавлен в индекс.`)
   } else {
+    const contentEntities = getEntitiesFromContent(content)
+    const practicesEntities = getPractice(fileName.replace('index.md', 'practice/'))
+    contentEntities.push(...practicesEntities)
     const object = {
       objectID: fileName.replace('index.md', ''),
-      title: commonSearch[fileName].title,
+      title: escape(commonSearch[fileName].title || ''),
       keywords: commonSearch[fileName].summary,
       tags: commonSearch[fileName].tags,
       category: fileName.replace(/\/.+/g, ''),
-      cover: {},
-      content: getEntitiesFromContent(content, patternsForEntities),
-      practice: getPractice(fileName.replace('index.md', 'practice/'))
-    }
-    if (typeof commonSearch[fileName].cover !== 'undefined' && typeof commonSearch[fileName].cover === 'object') {
-      object.cover = commonSearch[fileName].cover
-      if (typeof object.cover.desktop !== 'undefined' && typeof object.cover.desktop === 'string') {
-        object.cover.desktop = object.objectID + object.cover.desktop
-      }
-      if (typeof object.cover.mobile !== 'undefined' && typeof object.cover.mobile === 'string') {
-        object.cover.mobile = object.objectID + object.cover.mobile
-      }
+      content: contentEntities,
     }
     algoliaIndex.push(object)
   }

--- a/.github/scripts/search-index.js
+++ b/.github/scripts/search-index.js
@@ -29,8 +29,8 @@ const getEntitiesFromContent = (text) => {
     .filter(element => element.tagName.toLowerCase() !== 'pre')
     .map(element => {
       element.innerHTML = element.innerHTML
-        .replace('<code>', '`')
-        .replace('</code>', '`')
+        .replaceAll('<code>', '`')
+        .replaceAll('</code>', '`')
       return escape(element.textContent)
     })
 

--- a/.github/scripts/search-index.js
+++ b/.github/scripts/search-index.js
@@ -25,14 +25,10 @@ const getEntitiesFromContent = (text) => {
   const { document } = parseHTML(html)
 
   const output = Array.from(document.children)
-    // на данный момент игнорируем поиск по коду
-    .filter(element => element.tagName.toLowerCase() !== 'pre')
     .map(element => {
-      element.innerHTML = element.innerHTML
-        .replaceAll('<code>', '`')
-        .replaceAll('</code>', '`')
       return escape(element.textContent)
     })
+    .filter(Boolean)
 
   return output
 }
@@ -67,7 +63,12 @@ for (const fileName in commonSearch) {
 
     const description = commonSearch[fileName].description
     if (description) {
-      contentEntities.unshift(escape(description))
+      const descriptionHTML = md.render(description)
+      const { document } = parseHTML(descriptionHTML)
+      const descriptionText = Array.from(document.children)
+        .map(element => element.textContent)
+        .join('')
+      contentEntities.unshift(escape(descriptionText))
     }
 
     const object = {

--- a/.github/scripts/search-index.js
+++ b/.github/scripts/search-index.js
@@ -73,7 +73,7 @@ for (const fileName in commonSearch) {
     const object = {
       objectID: fileName.replace('index.md', ''),
       title: escape(commonSearch[fileName].title || ''),
-      keywords: commonSearch[fileName].summary,
+      keywords: commonSearch[fileName].keywords,
       tags: commonSearch[fileName].tags,
       category: fileName.replace(/\/.+/g, ''),
       content: contentEntities,

--- a/.github/scripts/search-index.js
+++ b/.github/scripts/search-index.js
@@ -86,4 +86,4 @@ for (const fileName in commonSearch) {
 const client = algoliaClient(process.env.ALGOLIA_APP_ID, process.env.ALGOLIA_API_KEY)
 const index = client.initIndex(process.env.ALGOLIA_APP_INDEX)
 
-index.saveObjects(algoliaIndex, { autoGenerateObjectIDIfNotExist: true })
+index.replaceAllObjects(algoliaIndex)

--- a/.github/workflows/update-index.yml
+++ b/.github/workflows/update-index.yml
@@ -23,7 +23,7 @@ jobs:
           ALGOLIA_API_KEY: ${{ secrets.ALGOLIA_API_KEY }}
           ALGOLIA_APP_INDEX: ${{ secrets.ALGOLIA_APP_INDEX }}
         run: |
-          npm install algoliasearch linkedom markdown-it yaml-cat --global
+          npm install algoliasearch linkedom html-escaper markdown-it yaml-cat --global
           npm link algoliasearch linkedom markdown-it
           yaml-cat -f json **/**/index.md -o search.json
           node .github/scripts/search-index.js


### PR DESCRIPTION
Вместо разделения на отдельные сущности - параграфы, заголовки, изображения и пр. - создаётся линейный список блочных элементов. Благодаря этому можно взять определённое количество таких элементов, в  которых есть совпадения, и вывести в результаты поиска.

Относится к [этому PR для сайта](https://github.com/doka-guide/platform/pull/866).