### PR TITLE
Перекрашивает демку и немного правит высоту

### DIFF
--- a/html/strong/demos/view/index.html
+++ b/html/strong/demos/view/index.html
@@ -12,12 +12,9 @@
       font-family: "Roboto", sans-serif;
       text-align: center;
       font-size: 24px;
-    }
-    @media screen and (prefers-color-scheme: dark) {
-      body {
-        background: black;
-        color: white;
-      }
+      background: #18191C;
+      color: white;
+      padding: 50px
     }
   </style>
 </head>

--- a/html/strong/demos/view/index.html
+++ b/html/strong/demos/view/index.html
@@ -13,6 +13,12 @@
       text-align: center;
       font-size: 24px;
     }
+    @media screen and (prefers-color-scheme: dark) {
+      body {
+        background: black;
+        color: white;
+      }
+    }
   </style>
 </head>
 <body>

--- a/html/strong/demos/view/index.html
+++ b/html/strong/demos/view/index.html
@@ -14,7 +14,8 @@
       font-size: 24px;
       background: #18191C;
       color: white;
-      padding: 50px
+      padding: 50px;
+      margin: 0;
     }
   </style>
 </head>

--- a/html/strong/index.md
+++ b/html/strong/index.md
@@ -19,7 +19,7 @@ tags:
 <p>Эта правка <strong>критически важна</strong> для проекта!</p>
 ```
 
-<iframe title="Как выглядит" src="demos/view/" height="80"></iframe>
+<iframe title="Как выглядит" src="demos/view/" height="180"></iframe>
 
 ## `<strong>` против `<b>`
 

--- a/html/strong/index.md
+++ b/html/strong/index.md
@@ -19,7 +19,7 @@ tags:
 <p>Эта правка <strong>критически важна</strong> для проекта!</p>
 ```
 
-<iframe title="Как выглядит" src="demos/view/" height="70"></iframe>
+<iframe title="Как выглядит" src="demos/view/" height="80"></iframe>
 
 ## `<strong>` против `<b>`
 


### PR DESCRIPTION
Проходил мимо статьи, демка показалась очень яркой на тёмной теме, добавил цвета и поправил высоту, чтобы полоса прокрутки не появлялась. 

Было:
![Screenshot 2021-12-13 at 21 07 46](https://user-images.githubusercontent.com/50330458/145865345-6c416443-d568-4a56-866b-21371249f590.png)

Стало:
![Screenshot 2021-12-13 at 21 08 14](https://user-images.githubusercontent.com/50330458/145865350-10471c3b-dc70-4cec-9d7f-4ba0f852d05c.png)


