### PR TITLE
Удаляет лишний экшен для проверки ссылок

### DIFF
--- a/.github/workflows/link-checker-all.yml
+++ b/.github/workflows/link-checker-all.yml
@@ -9,12 +9,6 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
-      - name: Проверка ссылок в исходниках
-        uses: JustinBeckwith/linkinator-action@v1
-        with:
-          paths: "**/*.md"
-          markdown: true
-          linksToSkip: "https?://(localhost|codepen.io)?(:[0-9]+)?/.*"
       - name: Проверка ссылок в собранном сайте
         uses: ruzickap/action-my-broken-link-checker@v2.2.5
         with:


### PR DESCRIPTION
Решает doka-guide/platform/issues/769

Как я уже писал в исходном ишью - у нас экшен проверки ссылок запускает два экшена:
1.  `JustinBeckwith/linkinator-action@v1` - он проверяет ссылки в переданных markdown файлах. Фактически же - [не работает](https://github.com/doka-guide/content/runs/4330856706?check_suite_focus=true#step:4:14).
2. `ruzickap/action-my-broken-link-checker` - проверяет настоящий сайт Доки. Сейчас его починили и он отлично работает, закрывая все потребности проверки битых ссылок.

Я спрашивал и в ПР и в ишью касательно удаления `JustinBeckwith/linkinator-action@v1` - никто не высказался против, правда никто и не подтвердил что нужно :)

Поэтому создал этот ПР, можем обсудить это здесь, а по итогу закрыть оригинальный ишью.