### PR TITLE
Дополняет про ::selection

### DIFF
--- a/css/selection/index.md
+++ b/css/selection/index.md
@@ -27,7 +27,7 @@ tags:
 
 После любого селектора дважды ставим двоеточие и пишем ключевое слово `selection`. Обратите внимание, что этому псевдоэлементу двойное двоеточие необходимо в отличие от других, которые принимают одно двоеточие.
 
-Для Mozilla Firefox необходимо использовать [вендорный префикс](/css/vendor-prefixes/):
+Для Mozilla Firefox версии 61 и ниже необходимо использовать [вендорный префикс](/css/vendor-prefixes/):
 
 ```css
 ::-moz-selection {
@@ -49,12 +49,10 @@ tags:
 
 - [`color`](/css/color/);
 - [`background-color`](/css/background-color/);
-- [`cursor`](/css/cursor/);
-- `caret-color`;
-- шорткат [`outline`](/css/outline/) и отдельные свойства обводки;
 - шорткат [`text-decoration`](/css/text-decoration/) и отдельные свойства оформления текста;
 - `text-emphasis-color`;
-- [`text-shadow`](/css/text-shadow/).
+- [`text-shadow`](/css/text-shadow/);
+- `stroke-color`, `fill-color` и `stroke-width` для SVG.
 
 Все прочие CSS-свойства, написанные внутри правила, будут проигнорированы.
 


### PR DESCRIPTION
По [спецификации](https://drafts.csswg.org/css-pseudo-4/#highlight-styling) `::selection` не умеет стилизовать cursor, caret-color и outline, но при этом умеет стилизовать текст в SVG.

На всякий случай проверил локально, умеет ли в браузерах мимо спецификации — не получилось изменить cursor и caret-color (каретка в принципе не видна, когда делается выделение), а outline — это история про box, который при выделении тоже сбрасывается. Смог сымитировать выделение и focus на элементе через принудительное выставление статуса в DevTools — всё равно внутри выделения цвет не меняется.

Также уточнил про версию Firefox, потому что современный Firefox в вендорном префиксе не нуждается.