### PR TITLE
nums[i] - пример с ошибкой

### DIFF
--- a/js/array-filter/index.md
+++ b/js/array-filter/index.md
@@ -174,7 +174,7 @@ const odds = []
 
 for (let i = 0; i < nums.length; i++) {
   if (nums[i] % 2 !== 0) {
-    odds.push(num)
+    odds.push(nums[i])
   }
 }
 


### PR DESCRIPTION
nums[i] - пример с ошибкой - 177 строка. Пушим переменную которой нет.