### PR TITLE
Добавляет статьи за январь в ченжлог

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ## Январь 2022
 
-- 30 января [`flat`](https://doka.guide/js/array-flat/), Рома Огарков
+- 30 января [`flat`](https://doka.guide/js/array-flat/), Рома Агарков
 - 28 января [`caret-color`](https://doka.guide/css/caret-color/), Миша Захаров
 - 25 января [`findIndex`](https://doka.guide/js/array-find-index/), Сергей Минаков
 - 25 января [`text-indent`](https://doka.guide/css/text-indent/), Матвей Романов

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@
 - 28 января [`caret-color`](https://doka.guide/css/caret-color/), Миша Захаров
 - 25 января [`findIndex`](https://doka.guide/js/array-find-index/), Сергей Минаков
 - 25 января [`text-indent`](https://doka.guide/css/text-indent/), Матвей Романов
-- 19 января [Статья про итератор](https://doka.guide/js/iterator/), Никита Канищев
+- 19 января [Итератор](https://doka.guide/js/iterator/), Никита Канищев
 - 12 января [`<i>`](https://doka.guide/html/i/), Гаджи Гаджидадаев
 
 ## Декабрь 2021

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 <!-- yaspeller ignore:start -->
 
+## Январь 2022
+
+- 30 января [`flat`](https://doka.guide/js/array-flat/), Рома Огарков
+- 25 января [`findIndex`](https://doka.guide/js/array-find-index/), Сергей Минаков
+- 25 января [`text-indent`](https://doka.guide/css/text-indent/), Матвей Романов
+
 ## Декабрь 2021
 
 - 29 декабря [`scroll-padding`](https://doka.guide/css/scroll-padding/), Алексей Орлов

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,8 +5,11 @@
 ## Январь 2022
 
 - 30 января [`flat`](https://doka.guide/js/array-flat/), Рома Огарков
+- 28 января [`caret-color`](https://doka.guide/css/caret-color/), Миша захаров
 - 25 января [`findIndex`](https://doka.guide/js/array-find-index/), Сергей Минаков
 - 25 января [`text-indent`](https://doka.guide/css/text-indent/), Матвей Романов
+- 19 января [Статья про итератор](https://doka.guide/js/iterator/), Никита Канищев
+- 12 января [`<i>`](https://doka.guide/html/i/), Гаджи Гаджидадаев
 
 ## Декабрь 2021
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@
 ## Январь 2022
 
 - 30 января [`flat`](https://doka.guide/js/array-flat/), Рома Огарков
-- 28 января [`caret-color`](https://doka.guide/css/caret-color/), Миша захаров
+- 28 января [`caret-color`](https://doka.guide/css/caret-color/), Миша Захаров
 - 25 января [`findIndex`](https://doka.guide/js/array-find-index/), Сергей Минаков
 - 25 января [`text-indent`](https://doka.guide/css/text-indent/), Матвей Романов
 - 19 января [Статья про итератор](https://doka.guide/js/iterator/), Никита Канищев


### PR DESCRIPTION
Мне понадобился список январских статей, но чейнджлога не нашёл. Сделал сам, надеюсь, всё правильно. 

Мы же дату считаем датой мержа?