### PR TITLE
Добавляет ключевое слово в статью про преобразование типов

### DIFF
--- a/js/typecasting/index.md
+++ b/js/typecasting/index.md
@@ -4,6 +4,8 @@ authors:
   - bespoyasov
 tags:
   - article
+keywords:
+  - приведение типов
 ---
 
 ## Кратко


### PR DESCRIPTION
При поиске "приведение типов" сейчас на первом месте выскакивает статья про `Map`, но если добавить ключевое слово, то по идее должна будет показываться нужная статья про преобразование типов