### PR TITLE
Переименовывает переменную в примере статьи «Порождающие паттерны проектирования»

### DIFF
--- a/js/design-patterns-creational/index.md
+++ b/js/design-patterns-creational/index.md
@@ -180,7 +180,7 @@ class Violinist implements Musician {
 }
 
 class Cellist implements Musician {
-  private instrument: Instrument = new ViolinCello();
+  private instrument: Instrument = new Cello();
 
   play = (piece) => piece.forEach((note) => this.instrument.playNote(note));
   // Playing A# on cello!


### PR DESCRIPTION
Fix a typo