### PR TITLE
Убирает плашку о поддержке в Safari

### DIFF
--- a/css/scroll-behavior/index.md
+++ b/css/scroll-behavior/index.md
@@ -10,12 +10,6 @@ tags:
 
 Управляет поведением прокрутки внутри блока. Значение `smooth` делает её плавной.
 
-<aside>
-
-⚠️ Safari пока не поддерживает `scroll-behavior` в стабильных версиях, но поддержка уже есть в [Safari Technology Preview](https://developer.apple.com/safari/download/).
-
-</aside>
-
 ## Пример
 
 ```css


### PR DESCRIPTION
## Описание

В Safari 15.4 [появилась поддержка scroll-behavior](https://caniuse.com/?search=scroll-behavior)

## Чек-лист

- [x] Текст оформлен [согласно руководству по стилю](https://github.com/doka-guide/content/blob/main/docs/styleguide.md)
- [x] Ссылки на внутренние материалы абсолютные и заканчиваются слэшем (`/css/color/`, `/tools/json/`)
- [x] Ссылки на картинки, видео и демки относительные (`demos/index.html`, `../demos/example.html`)
