### PR TITLE
Правит якорные ссылки

### DIFF
--- a/tools/gulp/index.md
+++ b/tools/gulp/index.md
@@ -410,6 +410,6 @@ exports.build = series(
 Если вы работаете над web-проектом, который:
 
 - не основан на современных [JS-фреймворках](/js/react-and-alternatives/);
-- не является [SPA](/js/web-app-types/#single-page-applications-spa/) или [PWA](/js/web-app-types/#progressive-web-applications-pwa/);
+- не является [SPA](/js/web-app-types/#single-page-applications-spa) или [PWA](/js/web-app-types/#progressive-web-applications-pwa);
 
 то Gulp — ваш бро, не сомневайтесь.


### PR DESCRIPTION
## Описание

В статье про Gulp есть две якорные ссылки, которые заканчиваются слешем. 

Исправляет.

## Чек-лист

<!-- Список для самопроверки. Поможет вам подготовить пул-реквест для быстрого мёрджа. Часть пунктов может быть неактуальна для вашей задачи, просто отметьте их как сделанные -->

- [ ] Текст оформлен [согласно руководству по стилю](https://github.com/doka-guide/content/blob/main/docs/styleguide.md)
- [x] Ссылки на внутренние материалы абсолютные и заканчиваются слэшем (`/css/color/`, `/tools/json/`)
- [ ] Ссылки на картинки, видео и демки относительные (`demos/index.html`, `../demos/example.html`)

P.S.: Возможно, нам нужно пересмотреть чек-лист, видимо, он вводит в заблуждение и люди ставят слеш там, где это не требуется. 