### PR TITLE
Поправляет автора в доке про `outline-width`

### DIFF
--- a/css/outline-width/index.md
+++ b/css/outline-width/index.md
@@ -1,10 +1,9 @@
 ---
 title: "`outline-width`"
 authors:
-  - doka-dog
+  - granondo
 tags:
   - doka
-  - placeholder
 ---
 
 ## Кратко


### PR DESCRIPTION
В пылу редактуры забыли вписать @Granondo автором доки про `outline-width` и убрать тег плейсхолдера