### PR TITLE
Добавляет ссылки на людей из редакции и на страницу с контрибьюторами

### DIFF
--- a/pages/about/index.md
+++ b/pages/about/index.md
@@ -15,18 +15,18 @@ location: "/about/"
 
 В редакцию входят:
 
-- **<!-- yaspeller ignore:start -->Алёна Батицкая<!-- yaspeller ignore:end -->** — редактор разделов [HTML](/html/) и [CSS](/css/).
-- **<!-- yaspeller ignore:start -->Вадим Макеев<!-- yaspeller ignore:end -->** — ревьюер разделов [HTML](/html/) и [CSS](/css/).
-- **<!-- yaspeller ignore:start -->Николай Лопин<!-- yaspeller ignore:end -->** — редактор разделов [JavaScript](/js/) и [Инструменты](/tools/).
-- **<!-- yaspeller ignore:start -->Саша Беспоясов<!-- yaspeller ignore:end -->** — ревьюер разделов [JavaScript](/js/) и [Инструменты](/tools/).
-- **<!-- yaspeller ignore:start -->Ольга Алексашенко<!-- yaspeller ignore:end -->** — литературный редактор.
+- **<!-- yaspeller ignore:start -->[Алёна Батицкая](/people/solarrust/)<!-- yaspeller ignore:end -->** — редактор разделов [HTML](/html/) и [CSS](/css/).
+- **<!-- yaspeller ignore:start -->[Вадим Макеев](/people/pepelsbey/)<!-- yaspeller ignore:end -->** — ревьюер разделов [HTML](/html/) и [CSS](/css/).
+- **<!-- yaspeller ignore:start -->[Николай Лопин](/people/nlopin/)<!-- yaspeller ignore:end -->** — редактор разделов [JavaScript](/js/) и [Инструменты](/tools/).
+- **<!-- yaspeller ignore:start -->[Саша Беспоясов](/people/bespoyasov/)<!-- yaspeller ignore:end -->** — ревьюер разделов [JavaScript](/js/) и [Инструменты](/tools/).
+- **<!-- yaspeller ignore:start -->[Ольга Алексашенко](/people/tachisis/)<!-- yaspeller ignore:end -->** — литературный редактор.
 
 Редакторы и ревьюеры работают с авторами, помогают делать пул-реквесты, планируют развитие и следят за тем, чтобы контент Доки был полным, актуальным, понятным и грамотным, чтобы у материалов были иллюстрации и демки.
 
-- **<!-- yaspeller ignore:start -->Кира Кустова<!-- yaspeller ignore:end -->** — иллюстратор, рисует обложки для статей.
-- **<!-- yaspeller ignore:start -->Света Коробцева<!-- yaspeller ignore:end -->** — дизайнер и разработчик демок, берёт обычные демки и превращает их в красивые и интерактивные.
-- **<!-- yaspeller ignore:start -->Игорь Коровченко<!-- yaspeller ignore:end -->** — бэкенд-разработчик, автоматизирует платформу и разрабатывает поиск.
-- **<!-- yaspeller ignore:start -->Егор Левченко<!-- yaspeller ignore:end -->** — амбассадор в сообществе, помогает новичкам и авторам вносить свой вклад в проект.
+- **<!-- yaspeller ignore:start -->[Кира Кустова](/people/kirakusto/)<!-- yaspeller ignore:end -->** — иллюстратор, рисует обложки для статей.
+- **<!-- yaspeller ignore:start -->[Света Коробцева](/people/skorobaeus/)<!-- yaspeller ignore:end -->** — дизайнер и разработчик демок, берёт обычные демки и превращает их в красивые и интерактивные.
+- **<!-- yaspeller ignore:start -->[Игорь Коровченко](/people/igsekor/)<!-- yaspeller ignore:end -->** — бэкенд-разработчик, автоматизирует платформу и разрабатывает поиск.
+- **<!-- yaspeller ignore:start -->[Егор Левченко](/people/furtivite/)<!-- yaspeller ignore:end -->** — амбассадор в сообществе, помогает новичкам и авторам вносить свой вклад в проект.
 
 Поддерживать работу редакции Доки помогает сервис онлайн-образования [Яндекс Практикум](https://practicum.yandex.ru/).
 
@@ -40,7 +40,7 @@ location: "/about/"
 
 ## Ваш ход!
 
-Дока — это вы, это ваш опыт и знания, которыми вы хотите поделиться с сообществом. Вы можете писать статьи, предлагать уточнения и правки, помогать с развитием платформы — словом, вы можете делать все, что по вашему мнению сделает Доку лучше. Почитайте о том, [как присоединиться к работе над Докой](https://github.com/doka-guide/content/blob/main/docs/contributing.md) и внести свой вклад.
+Дока — это вы, это ваш опыт и знания, которыми вы хотите поделиться с сообществом. Вы можете писать статьи, предлагать уточнения и правки, помогать с развитием платформы — словом, вы можете делать все, что по вашему мнению сделает Доку лучше. Почитайте о том, [как присоединиться к работе над Докой](https://github.com/doka-guide/content/blob/main/docs/contributing.md) и влиться в [сообщество замечательных людей](/people/), которые уже внесли свой вклад.
 
 ## Особая благодарность
 


### PR DESCRIPTION
## Описание

1. Добавляет ссылки на персональные страницы для членов редакции.
2. Добавляет ссылку [на страницу контрибьюторов](https://www.doka.guide/people/)

Это первая итерация, но начать можно с неё. Также стоит внимательно посмотреть на предложение со ссылкой на страницу контрибьюторов.

Плюс мне кажется странным раздел «Особая благодарность» в том виде, в котором он есть сейчас. Надо развернуть, что люди помогали нам на запуске. Плюс, возможно, перенести ссылку на замечательных контрибьюторов именно туда. 

## Чек-лист

<!-- Список для самопроверки. Поможет вам подготовить пул-реквест для быстрого мёрджа. Часть пунктов может быть неактуальна для вашей задачи, просто отметьте их как сделанные -->

- [ ] Текст оформлен [согласно руководству по стилю](https://github.com/doka-guide/content/blob/main/docs/styleguide.md)
- [x] Ссылки на внутренние материалы абсолютные, заканчиваются слэшем либо якорем на заголовок (`/css/color/`, `/tools/json/`, `/tools/gulp/#kak-ponyat`)
- [ ] Ссылки на картинки, видео и демки относительные (`demos/index.html`, `../demos/example.html`)
