### PR TITLE
Правит условие подогрева воды в кофемашине

### DIFF
--- a/js/design-patterns-structural/index.md
+++ b/js/design-patterns-structural/index.md
@@ -149,7 +149,7 @@ function heatWater() {
 
   machine.turnOnHeater();
 
-  if (machine.getTemperature() <= 90) {
+  if (machine.getTemperature() >= 90) {
     machine.turnOffHeater();
   }
 }


### PR DESCRIPTION
## Описание

if (machine.getTemperature() <= 90) { 
    machine.turnOffHeater();
}

По контексту нужно выключить подогрев воды когда температура будет выше или равна 90. Но с текущим условием подогрев будет выключаться сразу же, так как скорее всего температура воды при включении будет ниже 90.

## Чек-лист

- [x] Текст оформлен [согласно руководству по стилю](https://github.com/doka-guide/content/blob/main/docs/styleguide.md)
- [x] Ссылки на внутренние материалы абсолютные, заканчиваются слэшем либо якорем на заголовок (`/css/color/`, `/tools/json/`, `/tools/gulp/#kak-ponyat`)
- [x] Ссылки на картинки, видео и демки относительные (`demos/index.html`, `../demos/example.html`)
