### PR TITLE
Добавляет новое поле related в список разрешённых

### DIFF
--- a/.github/frontmatter.json
+++ b/.github/frontmatter.json
@@ -12,6 +12,7 @@
     "contributors",
     "editors",
     "keywords",
+    "related",
     "tags"
   ]
 }


### PR DESCRIPTION
## Описание

В Доке теперь есть возможность добавлять похожие или смежные по смыслу статьи, чтобы помочь читателю расширить кругозор или хорошо провести время. PR призван добавить это поле в список разрешённых для линтера меты.