### PR TITLE
Запускает сборку превью только после пройденных проверок

### DIFF
--- a/.github/workflows/pr-preview.yml
+++ b/.github/workflows/pr-preview.yml
@@ -2,6 +2,9 @@ name: PR Preview
 
 on:
   pull_request_target:
+  workflow_run:
+    workflows: ["PR Checks"]
+    types: [completed]
 
 jobs:
   prepare:


### PR DESCRIPTION
## Описание

Кажется можно не делать сборку статьи, если основные проверки провалились. Это предложение, давайте обсудим. 

@solarrust тебе как? или ты всегда хочешь иметь под рукой превью?