### PR TITLE
Добавляет плейсхолдер для доки про aria-placeholder

### DIFF
--- a/a11y/aria-placeholder/index.md
+++ b/a11y/aria-placeholder/index.md
@@ -20,7 +20,7 @@ tags:
 
 ## Кратко
 
-[Свойство виджета](/aria-attrs/#atributy-vidzhetov) из [WAI-ARIA](/a11y/aria-intro/#specifikaciya), которое устанавливает плейсхолдер для поля.
+[Свойство виджета](/aria-attrs/#atributy-vidzhetov) из [WAI-ARIA](/a11y/aria-intro/#specifikaciya), которое устанавливает плейсхолдер для поля ввода.
 
 Аналог `aria-placeholder` в HTML — атрибут [`placeholder`](/html/placeholder/).
 

--- a/a11y/aria-placeholder/index.md
+++ b/a11y/aria-placeholder/index.md
@@ -1,0 +1,42 @@
+---
+title: "`aria-placeholder`"
+description: "ARIA-атрибут для плейсхолдера к полю."
+authors:
+  - doka-dog
+keywords:
+  - доступность
+  - ARIA
+  - ARIA-атрибут
+  - плейсхолдер
+  - placeholder
+related:
+  - a11y/aria-intro
+  - a11y/aria-attrs
+  - html/placeholder
+tags:
+  - doka
+  - placeholder
+---
+
+## Кратко
+
+[Свойство виджета](/aria-attrs/#atributy-vidzhetov) из [WAI-ARIA](/a11y/aria-intro/#specifikaciya), которое устанавливает плейсхолдер для поля.
+
+Аналог `aria-placeholder` в HTML — атрибут [`placeholder`](/html/placeholder/).
+
+## Пример
+
+```html
+<span id="label">Любимое животное:</span>
+<span role="textbox" aria-labelledby="label" aria-placeholder="К примеру, голубоногая олуша" contenteditable></span>
+```
+
+## Как пишется
+
+Добавьте к тегу `aria-placeholder` с короткой текстовой подсказкой по заполнению поля. Атрибут можно использовать только для [`<input>`](/html/input/), [`<textarea>`](/html/textarea/), семантически нейтральных [`<div>`](/html/div/) и [`<span>`](/html/span/) или роли `textbox`.
+
+Для `<input>` и `<textarea>` лучше использовать атрибут `placeholder`.
+
+## Как понять
+
+Плейсхолдер — это короткая подсказка по заполнению поля. Она отображается внутри поля и исчезает при фокусе на нём. Плейсхолдер не заменяет подпись к полю.

--- a/a11y/aria-placeholder/index.md
+++ b/a11y/aria-placeholder/index.md
@@ -1,6 +1,6 @@
 ---
 title: "`aria-placeholder`"
-description: "ARIA-атрибут, который добавляет плейсхолдер к полю."
+description: "ARIA-атрибут, который добавляет плейсхолдер к полю ввода."
 authors:
   - doka-dog
 keywords:

--- a/a11y/aria-placeholder/index.md
+++ b/a11y/aria-placeholder/index.md
@@ -1,6 +1,6 @@
 ---
 title: "`aria-placeholder`"
-description: "ARIA-атрибут для плейсхолдера к полю."
+description: "ARIA-атрибут, который добавляет плейсхолдер к полю."
 authors:
   - doka-dog
 keywords:


### PR DESCRIPTION
## Описание

Плейсхолдер для #3033

## Чек-лист

- [x] Текст оформлен [согласно руководству по стилю](https://github.com/doka-guide/content/blob/main/docs/styleguide.md)
- [x] Ссылки на внутренние материалы абсолютные, заканчиваются слэшем либо якорем на заголовок (`/css/color/`, `/tools/json/`, `/tools/gulp/#kak-ponyat`)
- [x] Ссылки на картинки, видео и демки относительные (`demos/index.html`, `../demos/example.html`)
