### PR TITLE
Улучшает PR чекер

### DIFF
--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -19,7 +19,7 @@ jobs:
         run: |
           npm install editorconfig-checker --global
           config=.editorconfig
-          for changed_file in ${{ steps.files.outputs.all }}; do
+          for changed_file in ${{ steps.files.outputs.added_modified }}; do
             if [ $changed_file == $config ]
             then
               echo "Проверка для всех файлов"


### PR DESCRIPTION
## Описание

Теперь проверка форматирования не будет проверять удалённые файлы и сыпать в [логи](https://github.com/doka-guide/content/actions/runs/3082774153/jobs/4982885863) красным:

```
Проверка для .github/ISSUE_TEMPLATE/1_error_report.md
Could not get the ContentType of file: .github/ISSUE_TEMPLATE/1_error_report.md
stat .github/ISSUE_TEMPLATE/1_error_report.md: no such file or directory
```

Хотя проверки от этого не проваливались, но логи теперь будут без страшных красных надписей. Да и во всём 
остальном экшене и так использовался только `$steps.files.outputs.added_modified` и только в этом случае почему-то был `$steps.files.outputs.all`.