### PR TITLE
Правит опечатку в коде доки `.getElementsByClassName()`

### DIFF
--- a/js/getelementsbyclassname/index.md
+++ b/js/getelementsbyclassname/index.md
@@ -37,7 +37,7 @@ tags:
 
       const divEl = document.getElementById('title')
       // ищем параграфы внутри div:
-      const paragraphsFromDiv = document.getElementsByClassName('paragraph')
+      const paragraphsFromDiv = divEl.getElementsByClassName('paragraph')
       console.log(paragraphsFromDiv.length)
       // напечатает 1, так как внутри div только один элемент с классом paragraph
 


### PR DESCRIPTION
В 40-й строке по моему закралась ошибка, вместо document должен быть divEl.

## Описание

<!-- Кратко опишите изменение -->

Closes #<!-- проставьте номер ишью, которое решает задача или удалите строку, если ишью нет -->

## Чек-лист

<!-- Список для самопроверки. Поможет вам подготовить пул-реквест для быстрого мёрджа. Часть пунктов может быть неактуальна для вашей задачи, просто отметьте их как сделанные -->

- [x] Текст оформлен [согласно руководству по стилю](https://github.com/doka-guide/content/blob/main/docs/styleguide.md)
- [x] Ссылки на внутренние материалы абсолютные, заканчиваются слэшем либо якорем на заголовок (`/css/color/`, `/tools/json/`, `/tools/gulp/#kak-ponyat`)
- [x] Ссылки на картинки, видео и демки относительные (`demos/index.html`, `../demos/example.html`)
