### PR TITLE
Исправляет скрипт для дескрипшенов

### DIFF
--- a/.github/scripts/description-helper.js
+++ b/.github/scripts/description-helper.js
@@ -4,7 +4,7 @@ const fs = require('fs')
 const args = process.argv.slice(2)
 const ghKey = args.includes('--github-key') ? args[args.indexOf('--github-key') + 1] : false
 
-const issueHeaderText = `## Список статей со статусом дескрипшена:
+const issueHeaderText = `## Список статей без дескрипшена:
 
 `
 
@@ -36,9 +36,7 @@ if (ghKey) {
       if (fileName.indexOf(chapter) == 0) {
         const hasDescription = metaKeys.includes('description') && metaKeys['description'] !== ""
         const item = printItem(fileName, meta.title, hasDescription, meta.tags ? meta.tags.includes('placeholder') : false)
-        if (hasDescription) {
-          issueLists[chapter].pop(item)
-        } else {
+        if (!hasDescription) {
           issueLists[chapter].push(item)
         }
       }


### PR DESCRIPTION
## Описание

Раньше скрипт зачем-то удалял последнюю статью из массива, каждый раз, когда находил статью с дескрипшеном:

```js
const hasDescription = // some code
const item = // some code
if (hasDescription) {
  issueLists[chapter].pop(item)
} else {
  issueLists[chapter].push(item)
}
```

Поведение странное, как минимум потому что методу `pop()` не нужно никаких аргументов. Он всегда удаляет и возвращает последний элемент.

Из-за этого бага в соответствующих ищью на данный момент недостаёт 29 статей про CSS и 2 статьи про HTML.
