### PR TITLE
Улучшает плейсхолдер для доки про `aria-owns`

### DIFF
--- a/a11y/aria-owns/index.md
+++ b/a11y/aria-owns/index.md
@@ -21,7 +21,9 @@ tags:
 [Свойство связи](/a11y/aria-attrs/#atributy-svyazi) из [WAI-ARIA](/a11y/aria-intro/#specifikaciya). Указывает на то, что один элемент или несколько связаны с другими как родители или дети визуально, функционально или контекстно, но это не отражено в [DOM](/js/dom/).
 
 <aside>
+
 ⚠️ Пока [`aria-owns` не поддерживается](https://a11ysupport.io/tech/aria/aria-owns_attribute) VoiceOver в десктопном и мобильном Safari.
+
 </aside>
 
 ## Пример


### PR DESCRIPTION
## Описание

Добавила пробелы внутрь `<aside>`.

## Чек-лист

- [x] Текст оформлен [согласно руководству по стилю](https://github.com/doka-guide/content/blob/main/docs/styleguide.md)
- [x] Ссылки на внутренние материалы абсолютные, заканчиваются слэшем либо якорем на заголовок (`/css/color/`, `/tools/json/`, `/tools/gulp/#kak-ponyat`)
- [x] Ссылки на картинки, видео и демки относительные (`demos/index.html`, `../demos/example.html`)
