### PR TITLE
Добавляет ссылки к плейсхолдеру про `aria-disabled`

### DIFF
--- a/a11y/aria-disabled/index.md
+++ b/a11y/aria-disabled/index.md
@@ -42,7 +42,7 @@ tags:
 - [`<a>`](/html/a/) или [`link`](/a11y/role-link/).
 - [`<details>`](/html/details/), [`<fieldset>`](/html/fieldset/), [`<optgroup>`](/html/optgroup/) или `group`.
 - [`<hr>`](/html/hr/) или `separator`.
-- [`<div>`](/html/div/), [`<span>`](/html/span/) и `generic`.
+- [`<div>`](/html/div/), [`<span>`](/html/span/) или `generic`.
 - `tab`.
 - `scrollbar`.
 - `application`.

--- a/a11y/aria-disabled/index.md
+++ b/a11y/aria-disabled/index.md
@@ -38,8 +38,8 @@ tags:
 
 `aria-disabled` можно задавать только некоторым тегам и [ролям](/a11y/aria-roles/):
 
-- [`<button>`](/html/button/), [`<summary>`](/html/details/), [`<input>` c типами](/html/input/#type) `button`, `image`, `reset`, `submit` или для роли `button`.
-- [`<a>`](/html/a/) или `link`.
+- [`<button>`](/html/button/), [`<summary>`](/html/details/), [`<input>` c типами](/html/input/#type) `button`, `image`, `reset`, `submit` или для роли [`button`](/a11y/role-button/).
+- [`<a>`](/html/a/) или [`link`](/a11y/role-link/).
 - [`<details>`](/html/details/), [`<fieldset>`](/html/fieldset/), [`<optgroup>`](/html/optgroup/) или `group`.
 - [`<hr>`](/html/hr/) или `separator`.
 - [`<div>`](/html/div/), [`<span>`](/html/span/) и `generic`.


### PR DESCRIPTION
## Описание

Перелинковала с другими доками.

## Чек-лист

- [x] Текст оформлен [согласно руководству по стилю](https://github.com/doka-guide/content/blob/main/docs/styleguide.md)
- [x] Ссылки на внутренние материалы абсолютные, заканчиваются слэшем либо якорем на заголовок (`/css/color/`, `/tools/json/`, `/tools/gulp/#kak-ponyat`)
- [x] Ссылки на картинки, видео и демки относительные (`demos/index.html`, `../demos/example.html`)
