### PR TITLE
Добавляет ссылки в плейсхолдер доки про `aria-expanded`

### DIFF
--- a/a11y/aria-expanded/index.md
+++ b/a11y/aria-expanded/index.md
@@ -10,7 +10,7 @@ keywords:
 related:
   - a11y/aria-intro
   - a11y/aria-attrs
-  - a11y/aria-roles
+  - a11y/aria-controls
 tags:
   - doka
   - placeholder
@@ -46,8 +46,8 @@ tags:
 
 Атрибут можно использовать только для некоторых тегов и [ARIA-ролей](/a11y/aria-roles/):
 
-- [`<a>`](/html/a/) или `link`.
-- [`<button>`](/html/button/) или `button`.
+- [`<a>`](/html/a/) или [`link`](/a11y/role-link/).
+- [`<button>`](/html/button/) или [`button`](/a11y/role-button/).
 - [`<input type="checkbox">`](/html/input/#type) или `checkbox`.
 - [`<select>`](/html/select/) или `combobox`, `listbox`.
 - [`<tr>`](/html/tables/#tr) или `row`.
@@ -58,7 +58,7 @@ tags:
 - `treeitem`.
 - `gridcell`.
 
-Используйте `aria-expanded` вместе с `aria-controls` или `aria-owns`, когда контейнер с разворачивающимся содержимым не вложен в главный элемент.
+Используйте `aria-expanded` вместе с [`aria-controls`](/a11y/aria-controls/) или [`aria-owns`](/a11y/aria-owns/), когда контейнер с разворачивающимся содержимым не вложен в главный элемент.
 
 ## Как понять
 


### PR DESCRIPTION
## Описание

Перелинковала с другими доками и заменила одну связанную статью.

## Чек-лист

- [x] Текст оформлен [согласно руководству по стилю](https://github.com/doka-guide/content/blob/main/docs/styleguide.md)
- [x] Ссылки на внутренние материалы абсолютные, заканчиваются слэшем либо якорем на заголовок (`/css/color/`, `/tools/json/`, `/tools/gulp/#kak-ponyat`)
- [x] Ссылки на картинки, видео и демки относительные (`demos/index.html`, `../demos/example.html`)
