### PR TITLE
Добавляет ссылки к плейсхолдеру доки про роль `button`

### DIFF
--- a/a11y/role-button/index.md
+++ b/a11y/role-button/index.md
@@ -36,7 +36,7 @@ tags:
 
 Лучше использовать `<button>`, `<summary>` или `<input>` с типами `button`, `image`, `reset`, `submit` вместо роли `button`. Теги ведут себя как ссылки по умолчанию. Если используете роль `button`, то не обойтись без JavaScript.
 
-Для `button` можно использовать все [глобальные ARIA-атрибуты](/a11y/aria-attrs/#globalnye-atributy) и пару [атрибутов виджетов](/a11y/aria-attrs/#atributy-vidzhetov) — `aria-disabled`, `aria-haspopup`, `aria-expanded` и `aria-pressed`.
+Для `button` можно использовать все [глобальные ARIA-атрибуты](/a11y/aria-attrs/#globalnye-atributy) и пару [атрибутов виджетов](/a11y/aria-attrs/#atributy-vidzhetov) — [`aria-disabled`](/a11y/aria-disabled/), [`aria-haspopup`](/a11y/aria-haspopup/), [`aria-expanded`](/a11y/aria-expanded/) и [`aria-pressed`](/a11y/aria-pressed/).
 
 ## Как понять
 


### PR DESCRIPTION
## Описание

Перелинковала с другими доками.

## Чек-лист

- [x] Текст оформлен [согласно руководству по стилю](https://github.com/doka-guide/content/blob/main/docs/styleguide.md)
- [x] Ссылки на внутренние материалы абсолютные, заканчиваются слэшем либо якорем на заголовок (`/css/color/`, `/tools/json/`, `/tools/gulp/#kak-ponyat`)
- [x] Ссылки на картинки, видео и демки относительные (`demos/index.html`, `../demos/example.html`)
