### PR TITLE
Добавляет ссылку в плейсхолдер статьи про роль `alert`

### DIFF
--- a/a11y/role-alert/index.md
+++ b/a11y/role-alert/index.md
@@ -35,7 +35,7 @@ tags:
 
 Добавьте к тегу атрибут `role="alert"`. Роль можно использовать для всех тегов.
 
-У `alert` по умолчанию есть свойства [`aria-live="assertive"`](/a11y/aria-live/) и `aria-atomic="true"`.
+У `alert` по умолчанию есть свойства [`aria-live="assertive"`](/a11y/aria-live/) и [`aria-atomic="true"`](/a11y/aria-atomic/).
 
 [Скринридер](/a11y/screenreaders/) объявит сообщение с ролью `alert` сразу же, как только оно появится.
 


### PR DESCRIPTION
## Описание

Перелинковала доки.

## Чек-лист

- [x] Текст оформлен [согласно руководству по стилю](https://github.com/doka-guide/content/blob/main/docs/styleguide.md)
- [x] Ссылки на внутренние материалы абсолютные, заканчиваются слэшем либо якорем на заголовок (`/css/color/`, `/tools/json/`, `/tools/gulp/#kak-ponyat`)
- [x] Ссылки на картинки, видео и демки относительные (`demos/index.html`, `../demos/example.html`)
