### PR TITLE
Правит отступы

### DIFF
--- a/js/events/demos/this/index.html
+++ b/js/events/demos/this/index.html
@@ -12,6 +12,11 @@
     }
 
     body {
+      display: flex;
+			flex-direction: row;
+			justify-content: center;
+			flex-wrap: wrap;
+			gap: 25px;
       padding: 50px;
       background-color: #18191C;
       text-align: center;
@@ -34,10 +39,6 @@
 
     .button:active, .button:focus {
       outline: none;
-    }
-
-    .button + .button {
-      margin-left: 25px;
     }
   </style>
 </head>

--- a/js/events/demos/this/index.html
+++ b/js/events/demos/this/index.html
@@ -13,10 +13,10 @@
 
     body {
       display: flex;
-			flex-direction: row;
-			justify-content: center;
-			flex-wrap: wrap;
-			gap: 25px;
+      flex-direction: row;
+      justify-content: center;
+      flex-wrap: wrap;
+      gap: 25px;
       padding: 50px;
       background-color: #18191C;
       text-align: center;


### PR DESCRIPTION
## Описание

Ошибка: в мобильной версии у первого элемента отсутствовал отступ
Исправлено путем замены margin-left на flex-разметку

<details>
  <summary>Было</summary>

  ![Картинка с ошибкой](https://github.com/Terro216/archive/blob/1edc227d242f99f4497e4017468e4a44867a874d/dokaBefore.jpg?raw=true)

</details>
<details>
  <summary>Стало</summary>
  
  ![Картинка без ошибки](https://github.com/Terro216/archive/blob/main/dokaAfter.png?raw=true)

</details>


## Чек-лист

- [x] Текст оформлен [согласно руководству по стилю](https://github.com/doka-guide/content/blob/main/docs/styleguide.md)
- [x] Ссылки на внутренние материалы абсолютные, заканчиваются слэшем либо якорем на заголовок (`/css/color/`, `/tools/json/`, `/tools/gulp/#kak-ponyat`)
- [x] Ссылки на картинки, видео и демки относительные (`demos/index.html`, `../demos/example.html`)