### PR TITLE
Добавляет статьи из a11y в фичеринг

### DIFF
--- a/settings/featured.md
+++ b/settings/featured.md
@@ -1,7 +1,9 @@
 ---
 pinned:
-  - html/screenreaders
+  - a11y/chto-takoe-a11y
 ready:
+  - a11y/skip-link
+  - a11y/aria-labelledby
   - html/img
   - html/article
   - html/form


### PR DESCRIPTION
Запинила статью «Что такое доступность» и докинула в общую подборку ещё две: `aria-labelledby` и skip link.