### PR TITLE
Ослабляет правила по назначению лейблов разделов

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -1,21 +1,21 @@
 css:
   files:
-    - css/**/*.md
+    - css/**/*
 html:
   files:
-    - html/**/*.md
+    - html/**/*
 js:
   files:
-    - js/**/*.md
+    - js/**/*
 tools:
   files:
-    - tools/**/*.md
+    - tools/**/*
 a11y:
   files:
-    - a11y/**/*.md
+    - a11y/**/*
 'рецепт':
   files:
-    - recipes/**/*.md
+    - recipes/**/*
 'кухня':
   files:
     - .github/*.yml


### PR DESCRIPTION
Ставим лейбл раздела при изменении любого файла в разделе. Так мы точнее будем размечать разделы. 

До этого мы смотрели только на md-файлы и поэтому многие пул реквесты приходилось размечать руками. Например, изменение картинки или демки

