### PR TITLE
Правит примеры относительных ссылок

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -10,4 +10,4 @@ Closes #<!-- проставьте номер ишью, которое решае
 
 - [ ] Текст оформлен [согласно руководству по стилю](https://github.com/doka-guide/content/blob/main/docs/styleguide.md)
 - [ ] Ссылки на внутренние материалы абсолютные, заканчиваются слэшем либо якорем на заголовок (`/css/color/`, `/tools/json/`, `/tools/gulp/#kak-ponyat`)
-- [ ] Ссылки на картинки, видео и демки относительные (`images/box-model.png`, `demos/cracking/`)
+- [ ] Ссылки на картинки, видео и демки относительные (`images/box-model.png`, `demos/cracking/`, `../demos/example/`)

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -10,4 +10,4 @@ Closes #<!-- проставьте номер ишью, которое решае
 
 - [ ] Текст оформлен [согласно руководству по стилю](https://github.com/doka-guide/content/blob/main/docs/styleguide.md)
 - [ ] Ссылки на внутренние материалы абсолютные, заканчиваются слэшем либо якорем на заголовок (`/css/color/`, `/tools/json/`, `/tools/gulp/#kak-ponyat`)
-- [ ] Ссылки на картинки, видео и демки относительные (`images/box-model.png`, `demos/cracking/`, `../demos/example/`)
+- [ ] Ссылки на картинки, видео и демки относительные (`images/example.png`, `demos/example/`, `../demos/example/`)

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -10,4 +10,4 @@ Closes #<!-- проставьте номер ишью, которое решае
 
 - [ ] Текст оформлен [согласно руководству по стилю](https://github.com/doka-guide/content/blob/main/docs/styleguide.md)
 - [ ] Ссылки на внутренние материалы абсолютные, заканчиваются слэшем либо якорем на заголовок (`/css/color/`, `/tools/json/`, `/tools/gulp/#kak-ponyat`)
-- [ ] Ссылки на картинки, видео и демки относительные (`demos/index.html`, `../demos/example.html`)
+- [ ] Ссылки на картинки, видео и демки относительные (`images/box-model.png`, `demos/cracking/`)


### PR DESCRIPTION
## Описание

Поправил примеры для относительных ссылок в PR шаблоне: добавил пример с картинкой и добавил указание пути до папки демки вместо пути до файла.
