### PR TITLE
Уменьшает вычислительную сложность в примере получения cookie

### DIFF
--- a/js/cookie/index.md
+++ b/js/cookie/index.md
@@ -107,8 +107,8 @@ console.log(document.cookie);
 function getCookie() {
   return document.cookie.split('; ').reduce((acc, item) => {
     const [name, value] = item.split('=')
-
-    return { ...acc, [name]: value }
+    acc[name] = value
+    return acc
   }, {})
 }
 


### PR DESCRIPTION
В методе `getCookie` нет необходимости на каждой итерации делать поверхностное копирование объекта. Из-за этого значительно повышается сложность алгоритма.