### PR TITLE
Формирует новый фичеринг

### DIFF
--- a/settings/featured.md
+++ b/settings/featured.md
@@ -1,7 +1,12 @@
 ---
 pinned:
   - a11y/chto-takoe-a11y
+  - recipes/progress
+  - js/how-the-browser-creates-pages
 ready:
+  - a11y/screenreaders
+  - a11y/aria-intro
+  - a11y/aria-hidden
   - html/img
   - html/article
   - html/form
@@ -50,6 +55,8 @@ ready:
   - tools/webpack
   - tools/ci-cd
   - recipes/snow
+  - recipes/lets-encrypt-nginx
+  - recipes/progress
 active:
   - a11y/chto-takoe-a11y
   - tools/network


### PR DESCRIPTION
Докинула пару статей в запиненые, чтобы рядом с зелёной карточкой доступности точно не вставала другая зелёная карточка из инструментов. Плюс добавила несколько статей из доступности и из рецептов в список вселенского рандома. 

@HellSquirrel @TatianaFokina если вы хотите запинить или добавить в рандом какие-то статьи — самое время =)