### PR TITLE
Корректирует статью `css/text-align`

### DIFF
--- a/css/text-align/index.md
+++ b/css/text-align/index.md
@@ -29,8 +29,6 @@ p {
   text-align: center;
   text-align: justify;
   text-align: justify-all;
-  text-align: start;
-  text-align: end;
   text-align: match-parent;
 }
 ```


### PR DESCRIPTION
## Описание

<!-- Кратко опишите изменение -->

Удалил повторяющиеся значения свойства `text-align` в `Примеры`

## Чек-лист

<!-- Список для самопроверки. Поможет вам подготовить пул-реквест для быстрого мёрджа. Часть пунктов может быть неактуальна для вашей задачи, просто отметьте их как сделанные -->

- [x] Текст оформлен [согласно руководству по стилю](https://github.com/doka-guide/content/blob/main/docs/styleguide.md)
- [x] Ссылки на внутренние материалы абсолютные, заканчиваются слэшем либо якорем на заголовок (`/css/color/`, `/tools/json/`, `/tools/gulp/#kak-ponyat`)
- [x] Ссылки на картинки, видео и демки относительные (`images/example.png`, `demos/example/`, `../demos/example/`)
