### PR TITLE
Исправляет ссылку на профиль редактора доки

### DIFF
--- a/pages/about/index.md
+++ b/pages/about/index.md
@@ -17,7 +17,7 @@ location: "/about/"
 
 - **<!-- yaspeller ignore:start -->[Алёна Батицкая](/people/solarrust/)<!-- yaspeller ignore:end -->** — редактор разделов [HTML](/html/) и [CSS](/css/), тимлид Доки.
 - **<!-- yaspeller ignore:start -->[Полина Гуртовая](/people/hellsquirrel/)<!-- yaspeller ignore:end -->** — редактор разделов [JavaScript](/js/) и [Инструменты](/tools/).
-- **<!-- yaspeller ignore:start -->[Татьяна Фокина](/people/hellsquirrel/)<!-- yaspeller ignore:end -->** — редактор раздела [Доступность](/a11y/).
+- **<!-- yaspeller ignore:start -->[Татьяна Фокина](/people/tatianafokina/)<!-- yaspeller ignore:end -->** — редактор раздела [Доступность](/a11y/).
 - **<!-- yaspeller ignore:start -->[Саша Патлух](/people/pa7lux/)<!-- yaspeller ignore:end -->** — продюсер и стратег Доки.
 
 Редакторы и ревьюеры работают с авторами, помогают делать пул-реквесты, планируют развитие и следят за тем, чтобы контент Доки был полным, актуальным, понятным и грамотным, чтобы у материалов были иллюстрации и демки.


### PR DESCRIPTION
## Описание

Исправил ссылку на профиль @TatianaFokina в разделе [Кто мы](https://doka.guide/about/#kto-my) на странице [О проекте](https://doka.guide/about/)

## Чек-лист

- [x] Ссылки на внутренние материалы абсолютные, заканчиваются слэшем либо якорем на заголовок (`/css/color/`, `/tools/json/`, `/tools/gulp/#kak-ponyat`)