### PR TITLE
Исправляет код в доке `navigation`

### DIFF
--- a/a11y/role-navigation/index.md
+++ b/a11y/role-navigation/index.md
@@ -27,7 +27,7 @@ tags:
 
 ```html
 <header>
-  <span role="nav">
+  <span role="navigation">
     <ul>
       <li>
         <a href="/tapirs-life/">Где обитают тапиры</a>


### PR DESCRIPTION
## Описание

Исправила небольшую ошибку в названии роли в примере с кодом.

## Чек-лист

- [x] Текст оформлен [согласно руководству по стилю](https://github.com/doka-guide/content/blob/main/docs/styleguide.md)
- [x] Ссылки на внутренние материалы абсолютные, заканчиваются слэшем либо якорем на заголовок (`/css/color/`, `/tools/json/`, `/tools/gulp/#kak-ponyat`)
- [x] Ссылки на картинки, видео и демки относительные (`images/example.png`, `demos/example/`, `../demos/example/`)
