### PR TITLE
Исправляет опечатку в доке `.dataset`

### DIFF
--- a/js/element-dataset/index.md
+++ b/js/element-dataset/index.md
@@ -114,7 +114,7 @@ item.dataset.candidateRole = 'junior'
 
 ```html
 <ul>
-  <li data-candidate-role="junior" data-years-of-experience="1">Иван Иванов</li>
+  <li data-candidate-role="junior" data-years-of-experience="2">Иван Иванов</li>
 </ul>
 ```
 


### PR DESCRIPTION
Исправлена опечатка в примере использования.

## Описание

Было неверно указано число, которое использовалось в js-коде и которое выводилось по итогу в html.

## Чек-лист

<!-- Список для самопроверки. Поможет вам подготовить пул-реквест для быстрого мёрджа. Часть пунктов может быть неактуальна для вашей задачи, просто отметьте их как сделанные -->

- [x] Текст оформлен [согласно руководству по стилю](https://github.com/doka-guide/content/blob/main/docs/styleguide.md)
- [x] Ссылки на внутренние материалы начинаются со слеша и заканчиваются слэшем либо якорем на заголовок (`/css/color/`, `/tools/json/`, `/tools/gulp/#kak-ponyat`)
- [x] Ссылки на картинки, видео и демки относительные (`images/example.png`, `demos/example/`, `../demos/example/`)
