### PR TITLE
Заменяет устаревшую команду set-output в GitHub Actions

### DIFF
--- a/.github/workflows/pr-preview.yml
+++ b/.github/workflows/pr-preview.yml
@@ -18,7 +18,7 @@ jobs:
           list=$(echo $pr_files | grep -o '"filename": "[^"]*' | cut -d'"' -f4)
           mdReplaced=${list//md/html}
           returnReplaced=${list//$"\n"/ }
-          echo "::set-output name=all::$returnReplaced"
+          echo "all=$returnReplaced" >> $GITHUB_OUTPUT
           echo $returnReplaced
   pr-preview:
     runs-on: ubuntu-latest
@@ -57,7 +57,7 @@ jobs:
         run: |
           check_suite_url=$(curl -s -H "Accept: application/vnd.github.v3+json" https://api.github.com/repos/${{ github.repository }}/actions/runs/${{ github.run_id }} | jq -r '.check_suite_url')
           check_run_id=$(curl -s -H "Accept: application/vnd.github.v3+json" $check_suite_url/check-runs | jq '.check_runs[] | .id')
-          echo "::set-output name=check_id::$check_run_id"
+          echo "check_id=$check_run_id" >> $GITHUB_OUTPUT
       - name: Установка модулей
         run: npm ci
       - name: Сообщение о начале публикации превью
@@ -81,7 +81,7 @@ jobs:
           if ! [[ $file_list == "" ]]; then
             file_list=$(echo -e "<br><p>Список изменённых материалов:<ul>${file_list}</ul><p>")
           fi
-          echo ::set-output name=list::$(echo -e "${file_list}")
+          echo list=$(echo -e "${file_list}") >> $GITHUB_OUTPUT
       - name: Установка ключа для пользователя
         run: |
           set -eu

--- a/recipes/self-hosted-preview/index.md
+++ b/recipes/self-hosted-preview/index.md
@@ -56,7 +56,7 @@ jobs:
         run: |
           check_suite_url=$(curl -s -H "Accept: application/vnd.github.v3+json" https://api.github.com/repos/${{ github.repository }}/actions/runs/${{ github.run_id }} | jq -r '.check_suite_url')
           check_run_id=$(curl -s -H "Accept: application/vnd.github.v3+json" $check_suite_url/check-runs | jq '.check_runs[] | .id')
-          echo "::set-output name=check_id::$check_run_id"
+          echo "check_id=$check_run_id" >> $GITHUB_OUTPUT
       - name: Установка модулей
         run: npm ci
       - name: Сообщение о начале публикации превью


### PR DESCRIPTION
## Описание

Согласно [этой новости в блоге GitHub](https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/) от 11 октября 2022 команда `set-output` помечена устаревшей. Данный PR заменяет ее на рекомендуемый синтаксис во всех местах репозитория, где она встречалась, как в статье про экшены, так и в одном из экшенов.

## Чек-лист

- [x] Текст оформлен [согласно руководству по стилю](https://github.com/doka-guide/content/blob/main/docs/styleguide.md)
- [x] Ссылки на внутренние материалы начинаются со слеша и заканчиваются слэшем либо якорем на заголовок (`/css/color/`, `/tools/json/`, `/tools/gulp/#kak-ponyat`)
- [x] Ссылки на картинки, видео и демки относительные (`images/example.png`, `demos/example/`, `../demos/example/`)
