### PR TITLE
Добавляет небольшое уточнение в доку про `aria-labelledby`

### DIFF
--- a/a11y/aria-labelledby/index.md
+++ b/a11y/aria-labelledby/index.md
@@ -56,7 +56,7 @@ tags:
 
 Для [`<input>`](/html/input/) в первую очередь используйте `<label>`. У этого HTML-тега есть важная особенность — при клике по тегу фокус перемещается на поле по умолчанию.
 
-Ещё `aria-labelledby` можно связывать не только с видимыми элементами, но и со скрытыми с помощью [`hidden`](/html/hidden/), [`display: none`](/css/display/#kak-pishetsya) или [`visibility: hidden`](/css/visibility/#kak-pishetsya).
+Ещё `aria-labelledby` можно связывать не только с видимыми элементами, но и со скрытыми с помощью [`hidden`](/html/hidden/), [`display: none`](/css/display/#kak-pishetsya) или [`visibility: hidden`](/css/visibility/#kak-pishetsya). Учитывайте, что скринридер всё равно в этом случае прочитает связанную с элементом подпись к нему.
 
 В примере у переключателя скрыт лейбл «Ночной режим», но он всё равно доступен для вспомогательных технологий.
 


### PR DESCRIPTION
## Описание

Дополнила доку важным небольшим уточнением.

## Чек-лист

<!-- Список для самопроверки. Поможет вам подготовить пул-реквест для быстрого мёрджа. Часть пунктов может быть неактуальна для вашей задачи, просто отметьте их как сделанные -->

- [x] Текст оформлен [согласно руководству по стилю](https://github.com/doka-guide/content/blob/main/docs/styleguide.md)
- [x] Ссылки на внутренние материалы начинаются со слеша и заканчиваются слэшем либо якорем на заголовок (`/css/color/`, `/tools/json/`, `/tools/gulp/#kak-ponyat`)
- [x] Ссылки на картинки, видео и демки относительные (`images/example.png`, `demos/example/`, `../demos/example/`)
