### PR TITLE
Добавляет в шаблон в стайлгайде по демкам свойство `color-scheme: dark;`

### DIFF
--- a/docs/demos/style.md
+++ b/docs/demos/style.md
@@ -42,6 +42,10 @@
       box-sizing: border-box;
     }
 
+    html {
+      color-scheme: dark;
+    }
+    
     body {
       min-height: 100vh;
       padding: 50px;

--- a/docs/demos/style.md
+++ b/docs/demos/style.md
@@ -45,7 +45,7 @@
     html {
       color-scheme: dark;
     }
-    
+
     body {
       min-height: 100vh;
       padding: 50px;


### PR DESCRIPTION
## Описание

Добавляет в шаблон в стайлгайде по демкам свойство `color-scheme: dark;`, как [предлагал cergmin](https://github.com/doka-guide/content/issues/2303#:~:text=%D0%A1%D1%82%D0%BE%D0%B8%D1%82%20%D1%80%D0%B5%D0%BA%D0%BE%D0%BC%D0%B5%D0%BD%D0%B4%D0%BE%D0%B2%D0%B0%D1%82%D1%8C%20%D1%83%D1%81%D1%82%D0%B0%D0%BD%D0%B0%D0%B2%D0%BB%D0%B8%D0%B2%D0%B0%D1%82%D1%8C%20color%2Dscheme%3A%20dark%3B%2C%20%D0%B5%D1%81%D0%BB%D0%B8%20%D1%84%D0%BE%D0%BD%20%D1%82%D1%91%D0%BC%D0%BD%D1%8B%D0%B9%2C%20%D1%87%D1%82%D0%BE%D0%B1%D1%8B%20%D0%B5%D1%81%D0%BB%D0%B8%20%D0%B2%D0%B4%D1%80%D1%83%D0%B3%20%D0%BF%D0%BE%D1%8F%D0%B2%D0%B8%D0%BB%D1%81%D1%8F%20%D1%81%D0%BA%D1%80%D0%BE%D0%BB%D0%BB%D0%B1%D0%B0%D1%80%2C%20%D1%82%D0%BE%20%D0%BE%D0%BD%20%D1%82%D0%BE%D0%B6%D0%B5%20%D0%B1%D1%8B%D0%BB%20%D1%82%D1%91%D0%BC%D0%BD%D1%8B%D0%BC.).

## Чек-лист

- [x] Текст оформлен [согласно руководству по стилю](https://github.com/doka-guide/content/blob/main/docs/styleguide.md)
- [x] Ссылки на внутренние материалы начинаются со слеша и заканчиваются слэшем либо якорем на заголовок (`/css/color/`, `/tools/json/`, `/tools/gulp/#kak-ponyat`)
- [x] Ссылки на картинки, видео и демки относительные (`images/example.png`, `demos/example/`, `../demos/example/`)
