### PR TITLE
Исправляет ошибку в написании значений для `place-items`

### DIFF
--- a/css/grid-guide/index.md
+++ b/css/grid-guide/index.md
@@ -597,7 +597,7 @@ CSS Grid Layout ([спецификация](https://www.w3.org/TR/css-grid-1/)) 
 ```css
 .container {
   display: grid;
-  place-items: stretch / end;
+  place-items: stretch end;
 }
 ```
 

--- a/css/place-items/index.md
+++ b/css/place-items/index.md
@@ -18,13 +18,13 @@ tags:
 ```css
 .container {
   display: grid;
-  place-items: stretch / end;
+  place-items: stretch end;
 }
 ```
 
 ## Как пишется
 
-Пишутся два доступных значения для свойств [`align-items`](/css/align-items/) и [`justify-items`](/css/justify-items/), разделённые слэшем.
+Пишутся два доступных значения для свойств [`align-items`](/css/align-items/) и [`justify-items`](/css/justify-items/), разделённые пробелом.
 
 ## Подсказки
 


### PR DESCRIPTION
Исправление синтаксиса:
place-items: <'align-items'> <'justify-items'>;
Значения должны разделяться пробелом, а не слэшем.

## Описание

<!-- Кратко опишите изменение -->

Исправление синтаксиса place-items.
https://developer.mozilla.org/en-US/docs/Web/CSS/place-items

## Чек-лист

<!-- Список для самопроверки. Поможет вам подготовить пул-реквест для быстрого мёрджа. Часть пунктов может быть неактуальна для вашей задачи, просто отметьте их как сделанные -->

- [ ] Текст оформлен [согласно руководству по стилю](https://github.com/doka-guide/content/blob/main/docs/styleguide.md)
- [ ] Ссылки на внутренние материалы начинаются со слеша и заканчиваются слэшем либо якорем на заголовок (`/css/color/`, `/tools/json/`, `/tools/gulp/#kak-ponyat`)
- [ ] Ссылки на картинки, видео и демки относительные (`images/example.png`, `demos/example/`, `../demos/example/`)
