### PR TITLE
Исправляет опечатки в `Гайд по grid`

### DIFF
--- a/css/grid-guide/index.md
+++ b/css/grid-guide/index.md
@@ -590,6 +590,8 @@ CSS Grid Layout ([спецификация](https://www.w3.org/TR/css-grid-1/)) 
 
 ![Пример реализации свойства align-items со значением stretch.](images/22.png)
 
+Можно также управлять выравниванием отдельных грид-элементов при помощи свойства `align-self`.
+
 ### `place-items`
 
 Шорткат для указания значений сразу и для `align-items` и для `justify-items`. Указывать нужно именно в таком порядке.
@@ -670,7 +672,7 @@ CSS Grid Layout ([спецификация](https://www.w3.org/TR/css-grid-1/)) 
 ```css
 .container {
   display: grid;
-  grid:  auto-flow 30% / 200px 100px;
+  grid: auto-flow 30% / 200px 100px;
 }
 ```
 


### PR DESCRIPTION
## Описание

- Удаляет бесполезные комментарии.
- Добавляет упоминание `align-self` в `align-items`.
- Удаляет лишний пробел в примере кода.

## Чек-лист

- [x] Текст оформлен [согласно руководству по стилю](https://github.com/doka-guide/content/blob/main/docs/styleguide.md)
- [x] Ссылки на внутренние материалы начинаются со слеша и заканчиваются слэшем либо якорем на заголовок (`/css/color/`, `/tools/json/`, `/tools/gulp/#kak-ponyat`)
- [x] Ссылки на картинки, видео и демки относительные (`images/example.png`, `demos/example/`, `../demos/example/`)
