### PR TITLE
Исправлена опечатка в статье .map()

### DIFF
--- a/js/array-map/demos/index/index.html
+++ b/js/array-map/demos/index/index.html
@@ -149,11 +149,11 @@ function transformToCube(num) {
       </div>
       <div class="does-container">
         <button id="square" class="button button-yellow start">Давай квадраты</button>
-        <pre>products.map(transformToSquares)</pre>
+        <pre>products.map(transformToSquare)</pre>
       </div>
       <div class="does-container">
         <button id="cubes" class="button button-green start">А теперь кубы</button>
-        <pre>products.map(transformToCubes)</pre>
+        <pre>products.map(transformToCube)</pre>
       </div>
       <h2 class="subtitle">С каким элементом работаем</h2>
       <div class="items" id="container"></div>


### PR DESCRIPTION
## Описание

<!-- Кратко опишите изменение -->

В демо статьи js/array-map объявлены функции:
_function transformToSquare(num)_ и _function transformToCube(num)_

Далее они используются в качестве аргументов в:
_products.map(transformToSquare**s**)_ - изменено на _products.map(transformToSquare)_;
_products.map(transformToCube**s**)_ - изменено на _products.map(transformToCube)_.

## Чек-лист

<!-- Список для самопроверки. Поможет вам подготовить пул-реквест для быстрого мёрджа. Часть пунктов может быть неактуальна для вашей задачи, просто отметьте их как сделанные -->

- [x] Текст оформлен [согласно руководству по стилю](https://github.com/doka-guide/content/blob/main/docs/styleguide.md)
- [x] Ссылки на внутренние материалы начинаются со слеша и заканчиваются слэшем либо якорем на заголовок (`/css/color/`, `/tools/json/`, `/tools/gulp/#kak-ponyat`)
- [x]  Ссылки на картинки, видео и демки относительные (`images/example.png`, `demos/example/`, `../demos/example/`)
