### PR TITLE
Исправляет опечатку в статье "Счётчики в CSS"

### DIFF
--- a/css/css-counters/index.md
+++ b/css/css-counters/index.md
@@ -35,7 +35,7 @@ CSS-счётчики — это мощный инструмент для нум�
 
 ```css
 ul {
-  conter-reset: example 0;
+  counter-reset: example 0;
 }
 ```
 


### PR DESCRIPTION
## Описание

В статье "Счётчики в CSS" в примере кода опечатка в свойстве counter-reset, поправил её.

## Чек-лист

<!-- Список для самопроверки. Поможет вам подготовить пул-реквест для быстрого мёрджа. Часть пунктов может быть неактуальна для вашей задачи, просто отметьте их как сделанные -->

- [x] Текст оформлен [согласно руководству по стилю](https://github.com/doka-guide/content/blob/main/docs/styleguide.md)
- [x] Ссылки на внутренние материалы начинаются со слеша и заканчиваются слэшем либо якорем на заголовок (`/css/color/`, `/tools/json/`, `/tools/gulp/#kak-ponyat`)
- [x] Ссылки на картинки, видео и демки относительные (`images/example.png`, `demos/example/`, `../demos/example/`)
