### PR TITLE
Исправляет небольшую неточность в `Element`

### DIFF
--- a/js/element/index.md
+++ b/js/element/index.md
@@ -26,7 +26,7 @@ tags:
 
 ```js
 // получаем элемент из DOM
-const element = document.getElementsByTagName('h1')
+const element = document.getElementsByTagName('h1')[0]
 
 // после выполнения этого кода h1 будет выравнивать текст по центру
 element.align = 'center'


### PR DESCRIPTION
## Описание

В строке `const element = document.getElementsByTagName('h1')[0]` в конце добавляется `[0]`. Таким образом берется конкретный элемент. Без этого исправления код выдает ошибку.



