### PR TITLE
Исправляет опечатку в статье "currentColor"

### DIFF
--- a/css/currentcolor/index.md
+++ b/css/currentcolor/index.md
@@ -15,7 +15,7 @@ tags:
 
 ## Кратко
 
-Ключевое слова `currentColor` можно использовать в качестве значения для CSS-свойства, принимающего цвет. Например, [`background-color`](/css/background-color/). Браузер подставит вместо `currentColor` текущее значение свойства [`color`](/css/color/).
+Ключевое слово `currentColor` можно использовать в качестве значения для CSS-свойства, принимающего цвет. Например, [`background-color`](/css/background-color/). Браузер подставит вместо `currentColor` текущее значение свойства [`color`](/css/color/).
 
 ## Пример
 


### PR DESCRIPTION
## Описание

В статье "currentColor" в блоке "Кратко" опечатка в фразе "Ключевое слова", исправил

## Чек-лист

- [x] Текст оформлен [согласно руководству по стилю](https://github.com/doka-guide/content/blob/main/docs/styleguide.md)
- [x] Ссылки на внутренние материалы начинаются со слеша и заканчиваются слэшем либо якорем на заголовок (`/css/color/`, `/tools/json/`, `/tools/gulp/#kak-ponyat`)
- [x] Ссылки на картинки, видео и демки относительные (`images/example.png`, `demos/example/`, `../demos/example/`)
