### PR TITLE
Исправляет секцию `code` в демо для :where()

### DIFF
--- a/css/where/demos/basic/index.html
+++ b/css/where/demos/basic/index.html
@@ -29,6 +29,7 @@
     }
 
     h1 {
+      margin-top: 0;
       font-size: 26px;
       font-weight: 500;
     }
@@ -121,11 +122,7 @@
     }
 
     @media (max-width: 768px) {
-      body {
-        padding: 30px;
-      }
-
-      .code-section {
+      body, .code-section {
         padding: 30px;
       }
     }

--- a/css/where/demos/basic/index.html
+++ b/css/where/demos/basic/index.html
@@ -150,12 +150,16 @@
     const button = document.querySelector('button')
     const style = document.querySelector('style')
 
-    const codeBlockFooter = document.querySelector('#code-block-footer')
+    const cssFooterRule = `
+      ul .cat {
+        background-color: orange
+      }
+    `
 
     button.addEventListener('click', (event) => {
-      style.appendChild(document.createTextNode(codeBlockFooter.textContent))
+      style.appendChild(document.createTextNode(cssFooterRule))
 
-      codeBlockFooter.classList.remove('code-block_hidden')
+      document.querySelector('#code-block-footer').classList.remove('code-block_hidden')
 
       event.target.textContent = 'Котики покрашены'
       event.target.setAttribute('disabled', true)

--- a/css/where/demos/basic/index.html
+++ b/css/where/demos/basic/index.html
@@ -150,16 +150,12 @@
     const button = document.querySelector('button')
     const style = document.querySelector('style')
 
-    const cssFooterRule = `
-      ul .cat {
-        background-color: orange
-      }
-    `
+    const codeBlockFooter = document.querySelector('#code-block-footer')
 
     button.addEventListener('click', (event) => {
-      style.appendChild(document.createTextNode(cssFooterRule))
+      style.appendChild(document.createTextNode(codeBlockFooter.textContent))
 
-      document.querySelector('#code-block-footer').classList.remove('code-block_hidden')
+      codeBlockFooter.classList.remove('code-block_hidden')
 
       event.target.textContent = 'Котики покрашены'
       event.target.setAttribute('disabled', true)

--- a/css/where/demos/basic/index.html
+++ b/css/where/demos/basic/index.html
@@ -87,7 +87,7 @@
     }
 
     .code-section {
-      padding: 55px 40px;
+      padding: 40px;
       background-color: #282A2E;
       color: #E6E6E6;
     }
@@ -126,7 +126,7 @@
       }
 
       .code-section {
-        padding: 55px 30px;
+        padding: 30px;
       }
     }
   </style>

--- a/css/where/demos/basic/index.html
+++ b/css/where/demos/basic/index.html
@@ -138,7 +138,7 @@
       <pre><code class="code-block">:where(h1, ul) .cat {
   background-color: deepskyblue
 }</code>
-<code class="code-block code-block_hidden" id="code-block-footer">ul .cat {
+<code class="code-block code-block_hidden" id="code-block-color-override">ul .cat {
   background-color: orange
 }</code></pre>
     </div>
@@ -150,16 +150,16 @@
     const button = document.querySelector('button')
     const style = document.querySelector('style')
 
-    const cssFooterRule = `
+    const cssColorOverrideRule = `
       ul .cat {
         background-color: orange
       }
     `
 
     button.addEventListener('click', (event) => {
-      style.appendChild(document.createTextNode(cssFooterRule))
+      style.appendChild(document.createTextNode(cssColorOverrideRule))
 
-      document.querySelector('#code-block-footer').classList.remove('code-block_hidden')
+      document.querySelector('#code-block-color-override').classList.remove('code-block_hidden')
 
       event.target.textContent = 'Котики покрашены'
       event.target.setAttribute('disabled', true)

--- a/css/where/demos/basic/index.html
+++ b/css/where/demos/basic/index.html
@@ -56,6 +56,10 @@
       background-color: #2E9AFF;
     }
 
+    .button-pink {
+      background-color: #F498AD;
+    }
+
     .button:hover {
       background-color: #FFFFFF;
       cursor: pointer;
@@ -85,6 +89,7 @@
     footer {
       display: flex;
       justify-content: center;
+      gap: 25px;
     }
 
     .code-section {
@@ -121,6 +126,10 @@
       color: #000000;
     }
 
+    .hidden {
+      display: none;
+    }
+
     @media (max-width: 768px) {
       body, .code-section {
         padding: 30px;
@@ -149,26 +158,41 @@
       </div>
     </main>
     <footer>
-      <button class="button button-blue">Покрасить 25 голубых котов в рыжий</button>
+      <button id="play" class="button button-blue">Покрасить 25 голубых котов в рыжий</button>
+      <button id="reset" class="button button-pink hidden">Давайте ещё раз</button>
     </footer>
   </div>
   <script>
-    const button = document.querySelector('button')
+    const play = document.querySelector('#play')
+    const reset = document.querySelector('#reset')
     const style = document.querySelector('style')
 
     const cssColorOverrideRule = `
-      ul .cat {
-        background-color: #FF8630;
-      }
+    ul .cat {
+      background-color: #FF8630;
+    }
     `
 
-    button.addEventListener('click', (event) => {
+    play.addEventListener('click', (event) => {
       style.appendChild(document.createTextNode(cssColorOverrideRule))
 
       document.querySelector('#code-block-color-override').classList.remove('code-block_hidden')
 
       event.target.textContent = 'Котики покрашены'
       event.target.setAttribute('disabled', true)
+
+      reset.classList.toggle('hidden')
+    })
+
+    reset.addEventListener('click', (event) => {
+      style.innerText = style.innerText.substring(0, style.innerText.indexOf(cssColorOverrideRule))
+
+      document.querySelector('#code-block-color-override').classList.add('code-block_hidden')
+
+      play.textContent = 'Покрасить 25 голубых котов в рыжий'
+      play.removeAttribute('disabled')
+
+      reset.classList.toggle('hidden')
     })
   </script>
 </body>

--- a/css/where/demos/basic/index.html
+++ b/css/where/demos/basic/index.html
@@ -6,46 +6,31 @@
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <link rel="preconnect" href="https://fonts.googleapis.com">
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
-  <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Roboto&amp;family=Roboto+Mono&amp;display=swap">
+  <link href="https://fonts.googleapis.com/css2?family=Roboto+Mono&family=Roboto:wght@300;400;500&display=swap" rel="stylesheet">
   <style>
     * {
       box-sizing: border-box;
     }
 
-    html,
     body {
-      height: 100%;
+      min-height: 100vh;
+      margin: 0;
+      padding: 50px;
+      display: flex;
+      align-items: center;
+      justify-content: center;
+      background-color: #18191C;
+      color: #FFFFFF;
+      font-family: "Roboto", sans-serif;
     }
 
-    html {
-      font-size: 62.5%;
-
-      background-color: snow;
-    }
-
-    body,
-    button {
-      font-family: 'Roboto', sans-serif;
-    }
-
-    body {
-      width: 1000px;
-      max-width: 100%;
-
-      margin: auto;
-      padding: 1em;
-
-      font-size: 1.4rem;
-    }
-
-    @media (min-width: 768px) {
-      body {
-        font-size: 1.6rem;
-      }
+    .container {
+      max-width: 800px;
     }
 
     h1 {
-      font-size: 1.5em;
+      font-size: 26px;
+      font-weight: 500;
     }
 
     code {
@@ -53,31 +38,47 @@
       white-space: pre-wrap;
     }
 
-    button {
-      padding: 0.5em 1em;
-
-      border: none;
-      border-radius: 12px;
-
-      font-size: inherit;
-      color: white;
-
-      background-color: rgb(0 0 0 / 100%);
+    .button {
+      display: block;
+      min-width: 210px;
+      border: 2px solid transparent;
+      border-radius: 6px;
+      padding: 9px 15px;
+      color: #000000;
+      font-size: 18px;
+      font-weight: 300;
+      font-family: inherit;
+      transition: background-color 0.2s linear;
     }
 
-    button:hover {
+    .button-blue {
+      background-color: #2E9AFF;
+    }
+
+    .button:hover {
+      background-color: #FFFFFF;
       cursor: pointer;
+      transition: background-color 0.2s linear;
     }
 
-    button:disabled {
-      background-color: rgb(0 0 0 / 50%);
+    .button:focus-visible {
+      border: 2px solid #ffffff;
+      outline: none;
+    }
 
+    .button:focus {
+      border: 2px solid #ffffff;
+      outline: none;
+    }
+
+    .button:disabled {
+      opacity: 0.5;
       cursor: not-allowed;
     }
 
     header,
     main {
-      margin-bottom: 2em;
+      margin-bottom: 25px;
     }
 
     footer {
@@ -86,21 +87,16 @@
     }
 
     .code-section {
-      padding: 1em;
-
-      border-radius: 16px;
-
-      background-color: aquamarine;
+      padding: 55px 40px;
+      background-color: #282A2E;
+      color: #E6E6E6;
     }
 
     .code-block {
       display: block;
-
       visibility: visible;
       opacity: 1;
-
       transform: translateY(0);
-
       transition-property: transform, opacity;
       transition-duration: 300ms;
       transition-timing-function: ease;
@@ -109,7 +105,6 @@
     .code-block_hidden {
       visibility: hidden;
       opacity: 0;
-
       transform: translateY(1em);
     }
 
@@ -120,39 +115,53 @@
     }
 
     :where(h1, ul) .cat {
-      background-color: deepskyblue;
+      border-radius: 3px;
+      background-color: #2E9AFF;
+      color: #000000;
+    }
+
+    @media (max-width: 768px) {
+      body {
+        padding: 30px;
+      }
+
+      .code-section {
+        padding: 55px 30px;
+      }
     }
   </style>
 </head>
 <body>
-  <header>
-    <h1>Сколько <span class="cat">голубых котов</span> приходится на сотню шерстяных <!-- yaspeller ignore:start -->тыгыдыков<!-- yaspeller ignore:end -->?</h1>
-    <ul>
-      <li>50 чёрных кошек</li>
-      <li>25 полосатых котят</li>
-      <li><span class="cat">25 голубых котов</span></li>
-    </ul>
-  </header>
-  <main>
-    <div class="code-section">
-      <pre><code class="code-block">:where(h1, ul) .cat {
-  background-color: deepskyblue
+  <div class="container">
+    <header>
+      <h1>Сколько <span class="cat">голубых котов</span> приходится на сотню шерстяных <!-- yaspeller ignore:start -->тыгыдыков<!-- yaspeller ignore:end -->?</h1>
+      <ul>
+        <li>50 чёрных кошек</li>
+        <li>25 полосатых котят</li>
+        <li><span class="cat">25 голубых котов</span></li>
+      </ul>
+    </header>
+    <main>
+      <div class="code-section">
+        <pre><code class="code-block">:where(h1, ul) .cat {
+  background-color: deepskyblue;
 }</code>
-<code class="code-block code-block_hidden" id="code-block-color-override">ul .cat {
-  background-color: orange
+  <code class="code-block code-block_hidden" id="code-block-color-override">ul .cat {
+  background-color: orange;
 }</code></pre>
-    </div>
-  </main>
-  <footer>
-    <button>Покрасить 25 голубых котов в рыжий</button>
-  </footer>
+      </div>
+    </main>
+    <footer>
+      <button class="button button-blue">Покрасить 25 голубых котов в рыжий</button>
+    </footer>
+  </div>
   <script>
     const button = document.querySelector('button')
     const style = document.querySelector('style')
 
     const cssColorOverrideRule = `
       ul .cat {
-        background-color: orange
+        background-color: #FF8630;
       }
     `
 

--- a/css/where/demos/basic/index.html
+++ b/css/where/demos/basic/index.html
@@ -138,7 +138,7 @@
       <pre><code class="code-block">:where(h1, ul) .cat {
   background-color: deepskyblue
 }</code>
-<code class="code-block code-block_hidden" id="code-block-footer">footer .cat {
+<code class="code-block code-block_hidden" id="code-block-footer">ul .cat {
   background-color: orange
 }</code></pre>
     </div>

--- a/css/where/demos/specificity-battle/index.html
+++ b/css/where/demos/specificity-battle/index.html
@@ -12,43 +12,27 @@
       box-sizing: border-box;
     }
 
-    html,
-    body {
-      height: 100%;
-    }
-
-    html {
-      font-size: 62.5%;
-
-      background-color: snow;
-    }
-
-    body,
-    button {
-      font-family: 'Roboto', sans-serif;
-    }
-
     body {
       /* не даём появляться прокрутке при запуске эмодзи */
       overflow: hidden;
-
-      width: 1000px;
-      max-width: 100%;
-
-      margin: auto;
-      padding: 1em;
-
-      font-size: 1.4rem;
+      min-height: 100vh;
+      margin: 0;
+      padding: 50px;
+      display: flex;
+      align-items: center;
+      justify-content: center;
+      background-color: #18191C;
+      color: #FFFFFF;
+      font-family: "Roboto", sans-serif;
     }
 
-    @media (min-width: 768px) {
-      body {
-        font-size: 1.6rem;
-      }
+    .container {
+      max-width: 800px;
     }
 
     h1 {
-      font-size: 1.5em;
+      font-size: 26px;
+      font-weight: 500;
     }
 
     code {
@@ -56,25 +40,47 @@
       white-space: pre-wrap;
     }
 
-    button {
-      padding: 0.5em 1em;
-
-      border: none;
-      border-radius: 12px;
-
-      font-size: inherit;
-      color: white;
-
-      background-color: rgb(0 0 0 / 100%);
+    .button {
+      display: block;
+      min-width: 210px;
+      border: 2px solid transparent;
+      border-radius: 6px;
+      padding: 9px 15px;
+      color: #000000;
+      font-size: 18px;
+      font-weight: 300;
+      font-family: inherit;
+      transition: background-color 0.2s linear;
     }
 
-    button:hover {
+    .button-blue {
+      background-color: #2E9AFF;
+    }
+
+    .button:hover {
+      background-color: #FFFFFF;
       cursor: pointer;
+      transition: background-color 0.2s linear;
+    }
+
+    .button:focus-visible {
+      border: 2px solid #ffffff;
+      outline: none;
+    }
+
+    .button:focus {
+      border: 2px solid #ffffff;
+      outline: none;
+    }
+
+    .button:disabled {
+      opacity: 0.5;
+      cursor: not-allowed;
     }
 
     header,
     main {
-      margin-bottom: 2em;
+      margin-bottom: 25px;
     }
 
     footer {
@@ -83,25 +89,20 @@
     }
 
     .code-section {
-      padding: 1em;
-
-      border-radius: 16px;
-
-      background-color: aquamarine;
+      padding: 55px 40px;
+      background-color: #282A2E;
+      color: #E6E6E6;
     }
 
     .code-section + .code-section {
-      margin-top: 2em;
+      margin-top: 25px;
     }
 
     .code-block {
       display: block;
-
       visibility: visible;
       opacity: 1;
-
       transform: translateY(0);
-
       transition-property: transform, opacity;
       transition-duration: 300ms;
       transition-timing-function: ease;
@@ -110,43 +111,54 @@
     .code-block_hidden {
       visibility: hidden;
       opacity: 0;
-
       transform: translateY(1em);
     }
 
     .arrow-in-the-knee {
       visibility: hidden;
       opacity: 0;
-
       transition-property: opacity;
       transition-duration: 300ms;
       transition-timing-function: ease;
     }
+
+    @media (max-width: 768px) {
+      body {
+        overflow: auto;
+        padding: 30px;
+      }
+
+      .code-section {
+        padding: 55px 30px;
+      }
+    }
   </style>
 </head>
 <body>
-  <header>
-    <h1>Когда-то и меня вела дорога приключений... <span class="arrow-in-the-knee">а потом мне прострелили колено</span></h1>
-  </header>
-  <main>
-    <div class="code-section">
-      <pre><code class="code-block">&lth1&gtКогда-то и меня вела дорога приключений... &ltspan class="arrow-in-the-knee"&gtа потом мне прострелили колено&lt/span&gt&lt/h1&gt</code></pre>
-    </div>
-    <div class="code-section">
-      <pre><code class="code-block">.arrow-in-the-knee {
+  <div class="container">
+    <header>
+      <h1>Когда-то и меня вела дорога приключений... <span class="arrow-in-the-knee">а потом мне прострелили колено</span></h1>
+    </header>
+    <main>
+      <div class="code-section">
+        <pre><code class="code-block">&lth1&gtКогда-то и меня вела дорога приключений... &ltspan class="arrow-in-the-knee"&gtа потом мне прострелили колено&lt/span&gt&lt/h1&gt</code></pre>
+      </div>
+      <div class="code-section">
+        <pre><code class="code-block">.arrow-in-the-knee {
   visibility: hidden
 }</code>
-<code class="code-block code-block_hidden" id="code-block-is">:is(.arrow-in-the-knee) {
+  <code class="code-block code-block_hidden" id="code-block-is">:is(.arrow-in-the-knee) {
   visibility: visible
 }</code>
-<code class="code-block code-block_hidden" id="code-block-where">:where(.arrow-in-the-knee) {
+  <code class="code-block code-block_hidden" id="code-block-where">:where(.arrow-in-the-knee) {
   visibility: hidden
 }</code></pre>
-    </div>
-  </main>
-  <footer>
-    <button>Получить стрелу в колено</button>
-  </footer>
+      </div>
+    </main>
+    <footer>
+      <button class="button button-blue">Получить стрелу в колено</button>
+    </footer>
+  </div>
   <script>
     const button = document.querySelector('button')
     const style = document.querySelector('style')

--- a/css/where/demos/specificity-battle/index.html
+++ b/css/where/demos/specificity-battle/index.html
@@ -124,12 +124,7 @@
     }
 
     @media (max-width: 768px) {
-      body {
-        overflow: auto;
-        padding: 30px;
-      }
-
-      .code-section {
+      body, .code-section {
         padding: 30px;
       }
     }

--- a/css/where/demos/specificity-battle/index.html
+++ b/css/where/demos/specificity-battle/index.html
@@ -89,7 +89,7 @@
     }
 
     .code-section {
-      padding: 55px 40px;
+      padding: 40px;
       background-color: #282A2E;
       color: #E6E6E6;
     }
@@ -129,7 +129,7 @@
       }
 
       .code-section {
-        padding: 55px 30px;
+        padding: 30px;
       }
     }
   </style>

--- a/css/where/demos/specificity-battle/index.html
+++ b/css/where/demos/specificity-battle/index.html
@@ -31,6 +31,7 @@
     }
 
     h1 {
+      margin-top: 0;
       font-size: 26px;
       font-weight: 500;
     }

--- a/css/where/index.md
+++ b/css/where/index.md
@@ -3,6 +3,8 @@ title: "`:where()`"
 description: "Псевдокласс для упрощения перечисления нескольких селекторов."
 authors:
   - kotosha-real
+contributors:
+  - skorobaeus
 tags:
   - doka
 ---

--- a/css/where/index.md
+++ b/css/where/index.md
@@ -57,7 +57,7 @@ header:where(.content-header, .section-header) {
 
 Можно объяснить работу `:where()` как «возьми все селекторы из списка, но не добавляй им веса». Это полезно, если вы хотите применить стили к нескольким селекторам и при этом обойтись без перечисления, вдобавок не переживая о повышенной специфичности итогового селектора. Пример ниже демонстрирует возможность легко переопределить свойства, заданные с помощью `:where()`:
 
-<iframe title="Объяснение работы :where()" src="demos/basic" height="500"></iframe>
+<iframe title="Объяснение работы :where()" src="demos/basic" height="600"></iframe>
 
 ## Разница специфичности между `:where()` и `:is()`
 
@@ -85,7 +85,7 @@ div:where(.meow) {
 }
 ```
 
-<iframe title="Разница в специфичности :where() и :is()" src="demos/specificity-battle" height="700"></iframe>
+<iframe title="Разница в специфичности :where() и :is()" src="demos/specificity-battle" height="800"></iframe>
 
 ## Прощающие селекторы
 


### PR DESCRIPTION
## Описание

1. Поправил тег в секции `code` которая появляется после нажатия на кнопку в футере. Код в секции `code` теперь соответствует тому что применяется после нажатия на кнопку в футере
2. Поменял именование на более говорящее `Footer` => `ColorOverride`

## Чек-лист

<!-- Список для самопроверки. Поможет вам подготовить пул-реквест для быстрого мёрджа. Часть пунктов может быть неактуальна для вашей задачи, просто отметьте их как сделанные -->

- [x] Текст оформлен [согласно руководству по стилю](https://github.com/doka-guide/content/blob/main/docs/styleguide.md)
- [x] Ссылки на внутренние материалы начинаются со слеша и заканчиваются слэшем либо якорем на заголовок (`/css/color/`, `/tools/json/`, `/tools/gulp/#kak-ponyat`)
- [x] Ссылки на картинки, видео и демки относительные (`images/example.png`, `demos/example/`, `../demos/example/`)
