### PR TITLE
Исправляет название лейбла

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -7,7 +7,7 @@ html:
 js:
   files:
     - js/**/*
-tools:
+'веб-платформа':
   files:
     - tools/**/*
 a11y:


### PR DESCRIPTION
Поменялось название раздела «Инструмента». Нужно поменять лейбелер.