### PR TITLE
Чинит ошибку Link Checker 80

### DIFF
--- a/css/first-letter/index.md
+++ b/css/first-letter/index.md
@@ -34,7 +34,7 @@ blockquote::first-letter {
 Для псевдоэлемента сработает лишь небольшой набор CSS-свойств:
 
 - Шорткат [`font`](/css/font/) и шрифтовые свойства, начинающиеся на `font-`;
-- Шорткат [`background`](/css/backgroutn/) и свойства фона, начинающиеся на `background-`;
+- Шорткат [`background`](/css/background/) и свойства фона, начинающиеся на `background-`;
 - Шорткат [`margin`](/css/margin/) и внешние отступы, начинающиеся на `margin-`;
 - Шорткат [`padding`](/css/padding/) и внутренние отступы, начинающиеся на `padding-`;
 - Шорткат [`border`](/css/border/) и свойства рамок, начинающиеся на `border-`;

--- a/css/first-letter/index.md
+++ b/css/first-letter/index.md
@@ -34,7 +34,7 @@ blockquote::first-letter {
 Для псевдоэлемента сработает лишь небольшой набор CSS-свойств:
 
 - Шорткат [`font`](/css/font/) и шрифтовые свойства, начинающиеся на `font-`;
-- Шорткат [`background`](/css/backgroutnd/) и свойства фона, начинающиеся на `background-`;
+- Шорткат [`background`](/css/backgroutn/) и свойства фона, начинающиеся на `background-`;
 - Шорткат [`margin`](/css/margin/) и внешние отступы, начинающиеся на `margin-`;
 - Шорткат [`padding`](/css/padding/) и внутренние отступы, начинающиеся на `padding-`;
 - Шорткат [`border`](/css/border/) и свойства рамок, начинающиеся на `border-`;


### PR DESCRIPTION
## Описание

[Ссылка на ошибку](https://github.com/doka-guide/content/actions/runs/4381862476/jobs/7670344489)
Связано с #4298 и #4307

В прошлый раз ошибка была, но я её упустил.

## Чек-лист

- [x] Ссылки на внутренние материалы начинаются со слеша и заканчиваются слэшем либо якорем на заголовок (`/css/color/`, `/tools/json/`, `/tools/gulp/#kak-ponyat`)

