### PR TITLE
Добавляет плейсхолдер для `generic`

### DIFF
--- a/a11y/index.md
+++ b/a11y/index.md
@@ -44,6 +44,7 @@ groups:
   - name: 'Структура документа'
     items:
       - role-presentation-none
+      - role-generic
       - role-heading
       - role-img-image
       - role-list
@@ -126,6 +127,7 @@ groups:
       - role-status
       - role-timer
       - role-presentation-none
+      - role-generic
       - role-heading
       - role-img-image
       - role-list

--- a/a11y/role-generic/index.md
+++ b/a11y/role-generic/index.md
@@ -1,0 +1,24 @@
+---
+title: "`generic`"
+description: "Роль элемента-контейнера без имени и семантики."
+authors:
+  - doka-dog
+related:
+  - a11y/aria-roles
+  - html/div
+  - html/span
+tags:
+  - doka
+---
+
+## Кратко
+
+[Роль структуры документа](/a11y/aria-roles/) из [WAI-ARIA](/a11y/aria-intro/#specifikaciya). Означает, что у элемента нет семантики и имени.
+
+В HTML роль `generic` есть у [`<div>`](/html/div/) и [`<span>`](/html/span/).
+
+## Как пишется
+
+Роль `generic` нужна только браузерам, поэтому её не рекомендуют явно задавать элементам. Если хотите сбросить встроенную роль тега, используйте [`presentation`](/a11y/role-presentation-none/) или `none`.
+
+Элементам с ролью `generic` можно задавать все [глобальные ARIA-атрибуты](/a11y/aria-attrs/#globalnye-atributy), кроме атрибутов для имён и описаний. Это [`aria-label`](/a11y/aria-label/), [`aria-labelledby`](/a11y/aria-labelledby/), [`aria-roledescription`](/a11y/aria-roledescription/) и `aria-brailleroledescription`.

--- a/a11y/role-generic/index.md
+++ b/a11y/role-generic/index.md
@@ -13,7 +13,7 @@ tags:
 
 ## Кратко
 
-[Роль структуры документа](/a11y/aria-roles/) из [WAI-ARIA](/a11y/aria-intro/#specifikaciya). Означает, что у элемента нет семантики и имени.
+[Роль структуры документа](/a11y/aria-roles/#roli-struktury-dokumenta) из [WAI-ARIA](/a11y/aria-intro/#specifikaciya). Означает, что у элемента нет семантики и имени.
 
 В HTML роль `generic` есть у [`<div>`](/html/div/) и [`<span>`](/html/span/).
 

--- a/a11y/role-generic/index.md
+++ b/a11y/role-generic/index.md
@@ -9,6 +9,7 @@ related:
   - html/span
 tags:
   - doka
+  - placeholder
 ---
 
 ## Кратко

--- a/a11y/role-generic/index.md
+++ b/a11y/role-generic/index.md
@@ -19,6 +19,6 @@ tags:
 
 ## Как пишется
 
-Роль `generic` нужна только браузерам, поэтому её не рекомендуют явно задавать элементам. Если хотите сбросить встроенную роль тега, используйте [`presentation`](/a11y/role-presentation-none/) или `none`.
+Роль `generic` нужна только браузерам, и её не рекомендуют явно задавать элементам. Если хотите сбросить встроенную роль тега, используйте [`presentation`](/a11y/role-presentation-none/) или `none`.
 
 Элементам с ролью `generic` можно задавать все [глобальные ARIA-атрибуты](/a11y/aria-attrs/#globalnye-atributy), кроме атрибутов для имён и описаний. Это [`aria-label`](/a11y/aria-label/), [`aria-labelledby`](/a11y/aria-labelledby/), [`aria-roledescription`](/a11y/aria-roledescription/) и `aria-brailleroledescription`.


### PR DESCRIPTION
## Описание

Плейсхолдер доки про роль `generic`.

## Чек-лист

<!-- Список для самопроверки. Поможет вам подготовить пул-реквест для быстрого мёрджа. Часть пунктов может быть неактуальна для вашей задачи, просто отметьте их как сделанные -->

- [x] Текст оформлен [согласно руководству по стилю](https://github.com/doka-guide/content/blob/main/docs/styleguide.md)
- [x] Ссылки на внутренние материалы начинаются со слеша и заканчиваются слэшем либо якорем на заголовок (`/css/color/`, `/tools/json/`, `/tools/gulp/#kak-ponyat`)
- [x] Ссылки на картинки, видео и демки относительные (`images/example.png`, `demos/example/`, `../demos/example/`)
