### PR TITLE
Добавляет плейсхолдер для `aria-orientation`

### DIFF
--- a/a11y/aria-orientation/index.md
+++ b/a11y/aria-orientation/index.md
@@ -1,0 +1,31 @@
+---
+title: "`aria-orientation`"
+description: "ARIA-атрибут для обозначения расположения и ориентации интерактивного элемента на странице."
+authors:
+  - doka-dog
+related:
+  - a11y/aria-intro
+  - a11y/aria-attrs
+  - a11y/role-tablist
+tags:
+  - doka
+  - placeholder
+---
+
+## Кратко
+
+[Свойство виджета](/a11y/aria-attrs/#atributy-vidzhetov) из [WAI-ARIA](/a11y/aria-intro/#specifikaciya). Отражает ориентацию интерактивного элемента на странице — горизонтальную, вертикальную или неизвестную.
+
+Благодаря `aria-orientation` пользователи [скринридеров](/a11y/screenreaders/) поймут, с помощью каких клавиш могут перемещаться внутри элемента. Например, стрелками вверх и вниз.
+
+## Как пишется
+
+Добавьте к тегу атрибут `aria-orientation` с одним из значений:
+
+- `undefined` (по умолчанию) — положение элемента неизвестно или его сложно определить.
+- `horizontal` — элемент расположен горизонтально.
+- `vertical` — элемент расположен вертикально.
+
+Можно использовать `aria-orientation` для следующих тегов и [ARIA-ролей](/a11y/aria-roles/): [`<input type="range">`](/html/input/#type) или `slider`, [`tablist`](/a11y/role-tablist/), `scrollbar`, `separator`, `toolbar`, `menu`, `menubar`, `tree` и `listbox`.
+
+У этих тегов и ролей `aria-orientation` есть по умолчанию, но его значение можно менять в зависимости от ситуации. Например, `tablist` задан `aria-orientation="horizontal"`, а `scrollbar` — `aria-orientation="vertical"`.

--- a/a11y/index.md
+++ b/a11y/index.md
@@ -98,6 +98,7 @@ groups:
       - aria-controls
       - aria-owns
       - aria-modal
+      - aria-orientation
   - name: 'Доступные имена и описания'
     items:
       - aria-label
@@ -161,6 +162,7 @@ groups:
       - aria-busy
       - aria-owns
       - aria-modal
+      - aria-orientation
       - aria-current
       - aria-controls
       - aria-flowto


### PR DESCRIPTION
## Описание

Ещё один плесхолдер для ARIA-атрибута, который много где упоминается и ещё будет упомянут.

## Чек-лист

<!-- Список для самопроверки. Поможет вам подготовить пул-реквест для быстрого мёрджа. Часть пунктов может быть неактуальна для вашей задачи, просто отметьте их как сделанные -->

- [x] Текст оформлен [согласно руководству по стилю](https://github.com/doka-guide/content/blob/main/docs/styleguide.md)
- [x] Ссылки на внутренние материалы начинаются со слеша и заканчиваются слэшем либо якорем на заголовок (`/css/color/`, `/tools/json/`, `/tools/gulp/#kak-ponyat`)
- [x] Ссылки на картинки, видео и демки относительные (`images/example.png`, `demos/example/`, `../demos/example/`)
