### PR TITLE
Улучшает сообщение при выборе статьи или доки

### DIFF
--- a/new.sh
+++ b/new.sh
@@ -97,7 +97,13 @@ else
     esac
   done
 
-  read -r -p "$(echo "Введите название статьи: ")" TITLE
+  if [[ $TYPE == "doka" ]]; then
+    type="доки: "
+  else
+    type="статьи: "
+  fi
+
+  read -r -p "Введите название $type" TITLE
   read -r -p "$(echo "Введите название папки (используется для формирования ссылки): ")" FOLDER
 
 fi


### PR DESCRIPTION
## Описание

Раньше, при использовании `./new.sh` и выборе  "доки" показывалось сообщение "Введите название статьи:", меня это смутило, подумал, что выбрал неправильный тип. Теперь сообщение соответствует выбранному типу. 



## Чек-лист

<!-- Список для самопроверки. Поможет вам подготовить пул-реквест для быстрого мёрджа. Часть пунктов может быть неактуальна для вашей задачи, просто отметьте их как сделанные -->

- [ ] Текст оформлен [согласно руководству по стилю](https://github.com/doka-guide/content/blob/main/docs/styleguide.md)
- [ ] Ссылки на внутренние материалы начинаются со слеша и заканчиваются слэшем либо якорем на заголовок (`/css/color/`, `/tools/json/`, `/tools/gulp/#kak-ponyat`)
- [ ] Ссылки на картинки, видео и демки относительные (`images/example.png`, `demos/example/`, `../demos/example/`)
