### PR TITLE
Добавляет плейсхолдер для `menuitemradio`

### DIFF
--- a/a11y/index.md
+++ b/a11y/index.md
@@ -81,6 +81,7 @@ groups:
       - role-menu
       - role-button
       - role-link
+      - role-menuitemradio
       - role-tablist
       - role-tab
       - role-tabpanel
@@ -151,6 +152,7 @@ groups:
       - role-menu
       - role-button
       - role-link
+      - role-menuitemradio
       - role-checkbox
       - role-tablist
       - role-tab

--- a/a11y/role-menuitemradio/index.md
+++ b/a11y/role-menuitemradio/index.md
@@ -6,7 +6,7 @@ authors:
 related:
   - a11y/aria-intro
   - a11y/aria-roles
-  - a11y/aria-attrs
+  - a11y/aria-menu
 tags:
   - doka
   - placeholder

--- a/a11y/role-menuitemradio/index.md
+++ b/a11y/role-menuitemradio/index.md
@@ -26,6 +26,6 @@ tags:
 
 Не забудьте добавить `menuitemradio` в порядок фокуса с помощью [`tabindex`](/html/global-attrs/#tabindex).
 
-У элемента с `menuitemradio` обязательно должен быть атрибут [`aria-checked`](/a11y/aria-checked/), как у любой другой кастомной радиокнопки. Только у одного элемента в группе может быть `aria-checked="true"`.
+У элемента с `menuitemradio` обязательно должен быть атрибут [`aria-checked`](/a11y/aria-checked/), как у любой другой радиокнопки. Только у одного элемента в группе может быть `aria-checked="true"`.
 
 С ролью `menuitemradio` можно сочетать все [глобальные ARIA-атрибуты](/a11y/aria-attrs/#globalnye-atributy) и некоторые другие [атрибуты виджетов](/a11y/aria-attrs/#atributy-vidzhetov) — [`aria-disabled`](/a11y/aria-disabled/), [`aria-expanded`](/a11y/aria-expanded/), [`aria-haspopup`](/a11y/aria-haspopup/), `aria-posinset` и `aria-setsize`.

--- a/a11y/role-menuitemradio/index.md
+++ b/a11y/role-menuitemradio/index.md
@@ -1,0 +1,31 @@
+---
+title: "`menuitemradio`"
+description: "Роль пункта списка в виде радиокнопки из меню как в программе, операционной системе или приложении."
+authors:
+  - doka-dog
+related:
+  - a11y/aria-intro
+  - a11y/aria-roles
+  - a11y/aria-attrs
+tags:
+  - doka
+  - placeholder
+---
+
+## Кратко
+
+[Самостоятельная роль виджета](/a11y/aria-roles/#roli-vidzhetov) из [WAI-ARIA](/a11y/aria-intro/#specifikaciya) для пункта в виде радиокнопки из «настоящего» меню как в программе, операционной системе или приложении.
+
+В HTML нет тега с такой ролью.
+
+## Как пишется
+
+Задайте `role="menuitemradio"` любому тегу, лучше всего [`<div>`](/html/div/), [`<span>`](/html/span/) или [`<li>`](/html/li/).
+
+Элемент с `menuitemradio` обязательно должен находится внутри другого с [`menu`](/a11y/role-menu/) или `menubar`.
+
+Не забудьте добавить `menuitemradio` в порядок фокуса с помощью [`tabindex`](/html/global-attrs/#tabindex).
+
+У элемента с `menuitemradio` обязательно должен быть атрибут [`aria-checked`](/a11y/aria-checked/), как у любой другой кастомной радиокнопки. Только у одного элемента в группе может быть `aria-checked="true"`.
+
+С ролью `menuitemradio` можно сочетать все [глобальные ARIA-атрибуты](/a11y/aria-attrs/#globalnye-atributy) и некоторые другие [атрибуты виджетов](/a11y/aria-attrs/#atributy-vidzhetov) — [`aria-disabled`](/a11y/aria-disabled/), [`aria-expanded`](/a11y/aria-expanded/), [`aria-haspopup`](/a11y/aria-haspopup/), `aria-posinset` и `aria-setsize`.


### PR DESCRIPTION
## Описание

Плейсхолдер, связанный с другим про `menu`.

## Чек-лист

<!-- Список для самопроверки. Поможет вам подготовить пул-реквест для быстрого мёрджа. Часть пунктов может быть неактуальна для вашей задачи, просто отметьте их как сделанные -->

- [x] Текст оформлен [согласно руководству по стилю](https://github.com/doka-guide/content/blob/main/docs/styleguide.md)
- [x] Ссылки на внутренние материалы начинаются со слеша и заканчиваются слэшем либо якорем на заголовок (`/css/color/`, `/tools/json/`, `/tools/gulp/#kak-ponyat`)
- [x] Ссылки на картинки, видео и демки относительные (`images/example.png`, `demos/example/`, `../demos/example/`)
