### PR TITLE
Добавляет плейсхолдер для `menuitemcheckbox`

### DIFF
--- a/a11y/index.md
+++ b/a11y/index.md
@@ -79,6 +79,7 @@ groups:
   - name: 'Виджеты'
     items:
       - role-menu
+      - role-menuitemcheckbox
       - role-button
       - role-link
       - role-tablist
@@ -149,6 +150,7 @@ groups:
       - role-separator
       - role-tooltip
       - role-menu
+      - role-menuitemcheckbox
       - role-button
       - role-link
       - role-checkbox

--- a/a11y/role-menuitemcheckbox/index.md
+++ b/a11y/role-menuitemcheckbox/index.md
@@ -1,0 +1,31 @@
+---
+title: "`menuitemcheckbox`"
+description: "Роль пункта списка в виде чекбокса из меню как в программе, операционной системе или приложении."
+authors:
+  - doka-dog
+related:
+  - a11y/aria-intro
+  - a11y/aria-roles
+  - a11y/role-menu
+tags:
+  - doka
+  - placeholder
+---
+
+## Кратко
+
+[Самостоятельная роль виджета](/a11y/aria-roles/#roli-vidzhetov) из [WAI-ARIA](/a11y/aria-intro/#specifikaciya) для пункта в виде чекбокса или флажка из «настоящего» меню как в программе, операционной системе или в приложении.
+
+В HTML нет тега с такой ролью.
+
+## Как пишется
+
+Задайте `role="menuitemcheckbox"` любому тегу, лучше всего [`<div>`](/html/div/), [`<span>`](/html/span/) или [`<li>`](/html/li/).
+
+Элемент с `menuitemcheckbox` обязательно должен находится внутри другого с [`menu`](/a11y/role-menu/) или `menubar`.
+
+Не забудьте добавить `menuitemcheckbox` в порядок фокуса с помощью [`tabindex`](/html/global-attrs/#tabindex).
+
+У элемента с `menuitemcheckbox` обязательно должен быть атрибут [`aria-checked`](/a11y/aria-checked/), как у любого другого кастомного чекбокса. 
+
+С ролью `menuitemcheckbox` можно сочетать все [глобальные ARIA-атрибуты](/a11y/aria-attrs/#globalnye-atributy) и некоторые другие [атрибуты виджетов](/a11y/aria-attrs/#atributy-vidzhetov) — [`aria-disabled`](/a11y/aria-disabled/), [`aria-expanded`](/a11y/aria-expanded/), [`aria-haspopup`](/a11y/aria-haspopup/), `aria-posinset` и `aria-setsize`.

--- a/a11y/role-menuitemcheckbox/index.md
+++ b/a11y/role-menuitemcheckbox/index.md
@@ -26,6 +26,6 @@ tags:
 
 Не забудьте добавить `menuitemcheckbox` в порядок фокуса с помощью [`tabindex`](/html/global-attrs/#tabindex).
 
-У элемента с `menuitemcheckbox` обязательно должен быть атрибут [`aria-checked`](/a11y/aria-checked/), как у любого другого кастомного чекбокса. 
+У элемента с `menuitemcheckbox` обязательно должен быть атрибут [`aria-checked`](/a11y/aria-checked/), как у любого другого чекбокса.
 
 С ролью `menuitemcheckbox` можно сочетать все [глобальные ARIA-атрибуты](/a11y/aria-attrs/#globalnye-atributy) и некоторые другие [атрибуты виджетов](/a11y/aria-attrs/#atributy-vidzhetov) — [`aria-disabled`](/a11y/aria-disabled/), [`aria-expanded`](/a11y/aria-expanded/), [`aria-haspopup`](/a11y/aria-haspopup/), `aria-posinset` и `aria-setsize`.


### PR DESCRIPTION
## Описание

Плейсхолдер, связанный с другим про `menu`.

## Чек-лист

<!-- Список для самопроверки. Поможет вам подготовить пул-реквест для быстрого мёрджа. Часть пунктов может быть неактуальна для вашей задачи, просто отметьте их как сделанные -->

- [x] Текст оформлен [согласно руководству по стилю](https://github.com/doka-guide/content/blob/main/docs/styleguide.md)
- [x] Ссылки на внутренние материалы начинаются со слеша и заканчиваются слэшем либо якорем на заголовок (`/css/color/`, `/tools/json/`, `/tools/gulp/#kak-ponyat`)
- [x] Ссылки на картинки, видео и демки относительные (`images/example.png`, `demos/example/`, `../demos/example/`)
