### PR TITLE
Исправляет путь до фото контрибьютора

### DIFF
--- a/css/grid-guide/practice/meded90.md
+++ b/css/grid-guide/practice/meded90.md
@@ -42,4 +42,8 @@
 
 <iframe title="Гибкая сетка на гридах" src="../demos/mobile-example/" height="600"></iframe>
 
-<!-- yaspeller ignore:start -->Балдин Кирилл<!-- yaspeller ignore:end --> — наставник на курсе «[Мидл фронтенд-разработчик](https://practicum.yandex.ru/middle-frontend/?utm_source=pr&utm_medium=content&utm_campaign=middle-frontend_doka_content)» в Яндекс Практикуме.
+<!-- yaspeller ignore:start -->
+
+Балдин Кирилл — наставник на курсе «[Мидл фронтенд-разработчик](https://practicum.yandex.ru/middle-frontend/?utm_source=pr&utm_medium=content&utm_campaign=middle-frontend_doka_content)» в Яндекс Практикуме.
+
+<!-- yaspeller ignore:end -->

--- a/people/meded90/index.md
+++ b/people/meded90/index.md
@@ -1,7 +1,7 @@
 ---
 name: 'Балдин Кирилл'
 url: https://github.com/meded90
-photo: photo.jpg
+photo: photo.jpeg
 roles:
   - praktikum-mentor
 badges:


### PR DESCRIPTION
Кстати, попыталась тут же поправить партнёрскую ссылку тут https://doka.guide/css/grid-guide/#baldin-kirill-sovetuet внизу совета, но гит не показывает никаких изменений. @igsekor можешь, пожалуйста, глянуть, почему не произошла трансформация? Может из-за игнорирования имени?