### PR TITLE
Обновляет демки в «Селектор по атрибуту»

### DIFF
--- a/css/attribute-selector/demos/cite-bkg/index.html
+++ b/css/attribute-selector/demos/cite-bkg/index.html
@@ -2,7 +2,8 @@
 <html lang="ru">
 <head>
   <title>Фон для цитаты с атрибутом cite — Селектор по атрибут — Дока</title>
-  <meta charset="UTF-8">
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
   <link rel="preconnect" href="https://fonts.googleapis.com">
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
   <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Roboto&display=swap">
@@ -13,18 +14,28 @@
       box-sizing: border-box;
     }
 
+    html {
+      color-scheme: dark;
+    }
+
     body {
+      min-height: 100vh;
       padding: 50px;
+      display: grid;
+      place-items: center;
       background-color: #18191C;
       color: #FFFFFF;
-      font-size: 18px;
+      font-size: 16px;
       font-family: "Roboto", sans-serif;
     }
 
-    blockquote {
+    div {
       width: 65%;
       max-width: 750px;
-      margin: auto;
+    }
+
+    blockquote {
+      width: 100%;
       padding: 55px 40px;
       background-color: #FFFFFF;
       color: #123E66;
@@ -43,13 +54,28 @@
     blockquote[cite]::after {
       content: attr(cite);
       display: block;
-      margin-top: 20px;
+      margin-top: 10px;
       font-size: 16px;
       font-style: italic;
+    }
+
+    @media (max-width: 768px) {
+      body {
+        padding: 30px;
+      }
+
+      div {
+        width: 100%;
+      }
+
+      blockquote {
+        padding: 55px 30px;
+      }
     }
   </style>
 </head>
 <body>
+<div>
   <blockquote cite="А.С. Пушкин">
     Октябрь уж наступил — уж роща отряхает<br>
     Последние листы с нагих своих ветвей;
@@ -58,5 +84,6 @@
   <blockquote>
     Самое большое наше заблуждение в том, что у нас ещё много времени.
   </blockquote>
+</div>
 </body>
 </html>

--- a/css/attribute-selector/demos/link-icon/index.html
+++ b/css/attribute-selector/demos/link-icon/index.html
@@ -2,7 +2,8 @@
 <html lang="ru">
 <head>
   <title>Иконка для внешней ссылки — Селектор по атрибут — Дока</title>
-  <meta charset="UTF-8">
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
   <link rel="preconnect" href="https://fonts.googleapis.com">
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
   <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Roboto&display=swap">
@@ -13,28 +14,33 @@
       box-sizing: border-box;
     }
 
+    html {
+      color-scheme: dark;
+    }
+
     body {
+      min-height: 100vh;
       padding: 50px;
+      display: flex;
+      align-items: center;
+      justify-content: center;
       background-color: #18191C;
       color: #FFFFFF;
       font-family: "Roboto", sans-serif;
     }
 
     .list {
-      padding: 0;
       display: flex;
       justify-content: center;
       align-items: baseline;
       flex-wrap: wrap;
+      column-gap: 25px;
       list-style-type: none;
-    }
-
-    .list-item:nth-last-child(n + 2) {
-      margin-right: 25px;
     }
 
     a {
       font-size: 24px;
+      border-radius: 3px;
       color: inherit;
       -webkit-text-decoration-color: #2E9AFF;
       text-decoration-color: #2E9AFF;
@@ -42,14 +48,15 @@
       transition: background-color 0.2s linear;
     }
 
-    a:hover {
+    a:hover,
+    a:focus {
       background-color: #2E9AFF;
-      border-radius: 3px;
       transition: background-color 0.2s linear;
+      outline-width: 0;
     }
 
     /* Все ссылки с иконкой стрелочки */
-    [href^="http"]::after {
+    a::after {
       content: '';
       display: inline-block;
       width: 15px;
@@ -61,27 +68,33 @@
     }
 
     /* Внутренние ссылки без иконок */
-    [href*="/mysite.ru/"]::after {
+    [href*="/doka.guide/"]::after {
       display: none;
+    }
+
+    @media (max-width: 768px) {
+      body {
+        padding: 30px;
+      }
     }
   </style>
 </head>
 <body>
-  <nav>
-    <ul class="list">
-      <li class="list-item">
-        <a href="http://mysite.ru/about">О нас</a>
-      </li>
-      <li class="list-item">
-        <a href="http://mysite.ru/delivery">Доставка</a>
-      </li>
-      <li class="list-item">
-        <a href="http://mysite.ru/contacts">Контакты</a>
-      </li>
-      <li class="list-item">
-        <a href="http://medium.com/mysite-blog">Мы на Medium</a>
-      </li>
-    </ul>
-  </nav>
+<nav>
+  <ul class="list">
+    <li class="list-item">
+      <a href="https://doka.guide/about/">О нас</a>
+    </li>
+    <li class="list-item">
+      <a href="https://doka.guide/subscribe/">Рассылка</a>
+    </li>
+    <li class="list-item">
+      <a href="https://doka.guide/people/">Участники</a>
+    </li>
+    <li class="list-item">
+      <a href="https://discord.gg/NjaevcW8k8">Мы в Discord</a>
+    </li>
+  </ul>
+</nav>
 </body>
 </html>

--- a/css/attribute-selector/index.md
+++ b/css/attribute-selector/index.md
@@ -38,7 +38,6 @@ tags:
 ```css
 blockquote[cite] {
   background-color: #2E9AFF;
-  color: #000000;
 }
 ```
 

--- a/css/attribute-selector/practice/ezhkov.md
+++ b/css/attribute-selector/practice/ezhkov.md
@@ -1,16 +1,16 @@
 🛠 При помощи селектора по атрибуту круто стилизовать ссылки, основываясь на значении атрибута `href`. Можно визуально разделять ссылки, ведущие на соседние страницы сайта, и ссылки, ведущие на другие сайты:
 
 ```html
-<a href="http://mysite.ru/about">О нас</a>
-<a href="http://mysite.ru/delivery">Доставка</a>
-<a href="http://mysite.ru/contacts">Контакты</a>
-<a href="http://medium.com/mysite-blog">Мы на Medium</a>
+<a href="https://doka.guide/about/">О нас</a>
+<a href="https://doka.guide/subscribe/">Рассылка</a>
+<a href="https://doka.guide/people/">Участники</a>
+<a href="https://discord.gg/NjaevcW8k8">Мы в Discord</a>
 ```
 
 Все ссылки будут с иконкой стрелочки:
 
 ```css
-[href^="http"]::after {
+a::after {
   content: '';
   display: inline-block;
   background-image: url(arrow-top-right.svg);
@@ -20,9 +20,9 @@
 Внутренние ссылки — без иконок:
 
 ```css
-[href*="/mysite.ru/"]::after {
+[href*="/doka.guide/"]::after {
   display: none;
 }
 ```
 
-<iframe title="Иконка для внешней ссылки" src="../demos/link-icon/" height="140"></iframe>
+<iframe title="Иконка для внешней ссылки" src="../demos/link-icon/" height="150"></iframe>


### PR DESCRIPTION
## Описание

Заадаптивил демки и поменял ссылки в совете на доковские. Да, лучше вообще не использовать настоящие ссылки, но это лучше, чем те ссылки, которые были, ведь они были сломанными

## Ссылка

https://content-4647.dev.doka.guide/css/attribute-selector/
