### PR TITLE
Обновляет демки в `border-block`, `border-inline`

### DIFF
--- a/css/border-block/demos/border-block-basic/index.html
+++ b/css/border-block/demos/border-block-basic/index.html
@@ -29,6 +29,7 @@
       display: flex;
       align-items: center;
       justify-content: center;
+      text-align: center;
       background-color: #2E9AFF;
       width: 600px;
       height: 100px;

--- a/css/border-block/demos/border-block-language-change/index.html
+++ b/css/border-block/demos/border-block-language-change/index.html
@@ -29,6 +29,7 @@
       display: flex;
       align-items: center;
       justify-content: center;
+      text-align: center;
       background-color: #2E9AFF;
       width: 600px;
       height: 100px;

--- a/css/border-block/demos/border-inline/index.html
+++ b/css/border-block/demos/border-inline/index.html
@@ -29,6 +29,7 @@
       display: flex;
       align-items: center;
       justify-content: center;
+      text-align: center;
       background-color: #2E9AFF;
       width: 600px;
       height: 200px;

--- a/css/border-block/demos/border-language-change/index.html
+++ b/css/border-block/demos/border-language-change/index.html
@@ -29,6 +29,7 @@
       display: flex;
       align-items: center;
       justify-content: center;
+      text-align: center;
       background-color: #2E9AFF;
       width: 600px;
       height: 100px;

--- a/css/border-block/demos/border-top-bottom/index.html
+++ b/css/border-block/demos/border-top-bottom/index.html
@@ -29,6 +29,7 @@
       display: flex;
       align-items: center;
       justify-content: center;
+      text-align: center;
       background-color: #2E9AFF;
       width: 600px;
       height: 100px;

--- a/css/border-block/index.md
+++ b/css/border-block/index.md
@@ -94,4 +94,4 @@ div {
 }
 ```
 
-<iframe title="Рамка по строчной оси" src="demos/border-inline/" height="250"></iframe>
+<iframe title="Рамка по строчной оси" src="demos/border-inline/" height="300"></iframe>

--- a/css/border-inline/demos/border-block/index.html
+++ b/css/border-inline/demos/border-block/index.html
@@ -30,6 +30,7 @@
       display: flex;
       align-items: center;
       justify-content: center;
+      text-align: center;
       width: 600px;
       padding: 55px 40px;
       background-color: #2E9AFF;

--- a/css/border-inline/demos/border-inline-basic/index.html
+++ b/css/border-inline/demos/border-inline-basic/index.html
@@ -30,6 +30,7 @@
       display: flex;
       align-items: center;
       justify-content: center;
+      text-align: center;
       width: 600px;
       padding: 55px 40px;
       background-color: #2E9AFF;

--- a/css/border-inline/demos/border-inline-language-change/index.html
+++ b/css/border-inline/demos/border-inline-language-change/index.html
@@ -30,6 +30,7 @@
       display: flex;
       align-items: center;
       justify-content: center;
+      text-align: center;
       width: 600px;
       padding: 55px 40px;
       background-color: #2E9AFF;

--- a/css/border-inline/demos/border-language-change/index.html
+++ b/css/border-inline/demos/border-language-change/index.html
@@ -30,6 +30,7 @@
       display: flex;
       align-items: center;
       justify-content: center;
+      text-align: center;
       width: 600px;
       padding: 55px 40px;
       background-color: #2E9AFF;

--- a/css/border-inline/demos/border-left-right/index.html
+++ b/css/border-inline/demos/border-left-right/index.html
@@ -30,6 +30,7 @@
       display: flex;
       align-items: center;
       justify-content: center;
+      text-align: center;
       width: 600px;
       padding: 55px 40px;
       background-color: #2E9AFF;


### PR DESCRIPTION
## Описание

Маленький прчик, чтобы убрать скролл + добавил `text-align: center;`, чтобы на маленьких экранах текст оставался по середине 👉👈
