### PR TITLE
Обновляет демки в `caret-color`

### DIFF
--- a/css/caret-color/demos/form/index.html
+++ b/css/caret-color/demos/form/index.html
@@ -7,45 +7,79 @@
   <link rel="preconnect" href="https://fonts.gstatic.com/" crossorigin>
   <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Roboto&display=swap">
   <style>
+    *, *::before, *::after {
+      margin: 0;
+      padding: 0;
+      box-sizing: border-box;
+    }
+
     html {
-      display: grid;
-      height: 100%;
+      color-scheme: dark;
     }
 
     body {
+      min-height: 100vh;
       display: grid;
       place-content: center;
-      background-color: #18191c;
+      gap: 25px;
+      background-color: #18191C;
+      color: #FFFFFF;
+      font-family: "Roboto", sans-serif;
     }
 
     form {
       display: grid;
       place-content: center;
-      grid-row-gap: 10px;
-      caret-color: #ff8630;
+      gap: 25px;
+      caret-color: #FF8630;
     }
 
-    form label {
-      color: #ffffff;
-    }
-
-    form input {
+    input {
       display: block;
-      background-color: #ebebeb;
-      font-family: "Roboto", sans-serif;
-      padding: 5px;
+      width: 300px;
+      margin-top: 10px;
+      border: 1px solid #FFFFFF;
+      border-radius: 6px;
+      padding: 10px 15px;
+      background-color: transparent;
+      color: #FFFFFF;
+      font-size: 18px;
+      font-weight: 300;
+      font-family: inherit;
+      -webkit-appearance: none;
+      appearance: none;
     }
 
-    form textarea {
+    input:focus {
+      border-color: #2E9AFF;
+      outline: none;
+    }
+
+    textarea {
       display: block;
-      background-color: #ebebeb;
-      font-family: "Roboto", sans-serif;
-      caret-color: #0d47a1;
+      min-width: 300px;
+      max-width: 300px;
+      min-height: 100px;
+      max-height: 300px;
+      margin-top: 10px;
+      border: 1px solid #FFFFFF;
+      border-radius: 6px;
+      padding: 10px 15px;
+      background-color: transparent;
+      color: #FFFFFF;
+      font-size: 18px;
+      font-weight: 300;
+      font-family: inherit;
+      caret-color: #2E9AFF;
+    }
+
+    textarea:focus {
+      border-color: #2E9AFF;
+      outline: none;
     }
 
     p {
-      color: #ffffff;
-      caret-color: #00dd00;
+      caret-color: #F498AD;
     }
   </style>
 </head>
@@ -63,6 +97,6 @@
     </label>
   </form>
 
-  <p contenteditable>Зелёная каретка</p>
+  <p contenteditable>Розовая каретка</p>
 </body>
 </html>

--- a/css/caret-color/demos/paint-the-caret/index.html
+++ b/css/caret-color/demos/paint-the-caret/index.html
@@ -7,70 +7,80 @@
   <link rel="preconnect" href="https://fonts.gstatic.com/" crossorigin>
   <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Roboto&display=swap">
   <style>
+    *, *::before, *::after {
+      margin: 0;
+      padding: 0;
+      box-sizing: border-box;
+    }
+
     html {
-      display: grid;
-      height: 100%;
+      color-scheme: dark;
     }
 
     body {
+      min-height: 100vh;
       display: grid;
       place-content: center;
-      grid-row-gap: 10px;
-      background-color: #18191c;
-    }
-
-    label {
-      color: #ffffff;
+      gap: 25px;
+      background-color: #18191C;
+      color: #FFFFFF;
+      font-family: "Roboto", sans-serif;
     }
 
     input {
       display: block;
-      background-color: #ebebeb;
-      font-family: "Roboto", sans-serif;
-      padding: 5px;
+      width: 300px;
+      margin-top: 10px;
+      border: 1px solid #FFFFFF;
+      border-radius: 6px;
+      padding: 10px 15px;
+      background-color: transparent;
+      color: #FFFFFF;
+      font-size: 18px;
+      font-weight: 300;
+      font-family: inherit;
+      -webkit-appearance: none;
+      appearance: none;
     }
 
-    .red {
-      caret-color: #cc0000;
+    input:focus {
+      border-color: #2E9AFF;
+      outline: none;
+    }
+
+    .orange {
+      caret-color: #FF8630;
     }
 
     .green {
-      caret-color: #00DD00;
+      caret-color: #41E847;
     }
 
     .blue {
-      caret-color: #0882ff;
+      caret-color: #2E9AFF;
     }
 
     .yellow {
-      caret-color: #ffd600;
-    }
-
-    .blueviolet {
-      caret-color: #6e4aff;
+      caret-color: #FFD829;
     }
   </style>
 </head>
 <body>
   <label>
-    Красная каретка
-    <input class="red" type="text" placeholder="Красная каретка">
+    Оранжевая каретка
+    <input class="orange" type="text">
   </label>
   <label>
     Зелёная каретка
-    <input class="green" type="text" placeholder="Зелёная каретка">
+    <input class="green" type="text">
   </label>
   <label>
     Синяя каретка
-    <input class="blue" type="text" placeholder="Синяя каретка">
+    <input class="blue" type="text">
   </label>
   <label>
     Жёлтая каретка
-    <input class="yellow" type="text" placeholder="Жёлтая каретка">
-  </label>
-  <label>
-    Сине-фиолетовая каретка
-    <input class="blueviolet" type="text" placeholder="Сине-фиолетовая каретка">
+    <input class="yellow" type="text">
   </label>
 </body>
 </html>

--- a/css/caret-color/demos/rainbow-input/index.html
+++ b/css/caret-color/demos/rainbow-input/index.html
@@ -5,57 +5,71 @@
     <meta charset="utf-8">
     <meta name="viewport" content="width=device-width, initial-scale=1">
     <link rel="preconnect" href="https://fonts.gstatic.com/" crossorigin>
-    <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Roboto&display=swap">
+    <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Roboto:wght@300;400&display=swap">
+    <style>
+      *, *::before, *::after {
+        margin: 0;
+        padding: 0;
+        box-sizing: border-box;
+      }
+
+      html {
+        color-scheme: dark;
+      }
+
+      body {
+        min-height: 100vh;
+        padding: 30px;
+        display: flex;
+        align-items: center;
+        justify-content: center;
+        background-color: #18191C;
+        color: #FFFFFF;
+        font-family: "Roboto", sans-serif;
+      }
+
+      input {
+        display: block;
+        width: 600px;
+        margin-top: 10px;
+        border: 1px solid #FFFFFF;
+        border-radius: 6px;
+        padding: 10px 15px;
+        background-color: transparent;
+        color: inherit;
+        font-size: 64px;
+        font-weight: 300;
+        font-family: inherit;
+        -webkit-appearance: none;
+        appearance: none;
+      }
+
+      input:focus {
+        animation: 3s infinite rainbow;
+        border-color: #2E9AFF;
+        outline: none;
+      }
+
+      @keyframes rainbow {
+        0% { caret-color: #F498AD; }
+        20% { caret-color: #FF8630; }
+        40% { caret-color: #FFD829; }
+        60% { caret-color: #41E847; }
+        80% { caret-color: #2E9AFF; }
+        100% { caret-color: #F498AD; }
+      }
+
+      @media (max-width: 768px) {
+        input {
+          width: 100%;
+        }
+      }
+    </style>
   </head>
-
-  <style>
-    @keyframes rainbow {
-      0% { caret-color: red; }
-      20% { caret-color: orange; }
-      40% { caret-color: yellow; }
-      60% { caret-color: green; }
-      80% { caret-color: blue; }
-      100% { caret-color: purple; }
-    }
-
-    html {
-      display: grid;
-      height: 100%;
-    }
-
-    body {
-      display: grid;
-      place-content: center;
-      background-color: #18191c;
-    }
-
-    label {
-      color: #ffffff;
-      padding-bottom: 10px;
-    }
-
-    input {
-      display: block;
-      width: 60vw;
-      height: 50px;
-      font-family: "Roboto", sans-serif;
-      font-size: 50px;
-      caret-color: red;
-      background-color: rgb(255 255 255 / 0.1);
-      color: #eeeeee;
-      border-radius: 1rem;
-      border: 2px dotted rgb(255 255 255 / 0.1);
-    }
-
-    input:focus {
-      animation: 3s infinite rainbow;
-    }
-  </style>
-
   <body>
     <label>
       Текстовая каретка с радужной анимацией!
-      <input type="text" autofocus value="Радуга!">
+      <input type="text" value="Радуга!">
     </label>
   </body>
 </html>

--- a/css/caret-color/index.md
+++ b/css/caret-color/index.md
@@ -27,21 +27,14 @@ tags:
 ```
 
 ```css
-input {
-  display: block;
-  background-color: #ebebeb;
-  font-family: "Roboto", sans-serif;
-  padding: 5px;
-}
-
 .red {
-  caret-color: #cc0000;
+  caret-color: red;
 }
 ```
 
 В примере ниже ещё несколько полей ввода с каретками разного цвета:
 
-<iframe title="Как красить каретку" src="demos/paint-the-caret/" height="330"></iframe>
+<iframe title="Как красить каретку" src="demos/paint-the-caret/" height="470"></iframe>
 
 ## Как пишется
 
@@ -57,7 +50,7 @@ input {
 
 ## Ещё пример
 
-В данном примере мы создадим форму с несколькими полями ввода, для формы зададим оранжевый цвет каретки, [`<input>`](/html/input/) будет наследовать свойство от формы, для [`<textarea>`](/html/textarea/) переопределим его на синий, а для параграфа с атрибутом [`contenteditable`](/html/global-attrs/) зададим зелёный цвет каретки:
+В данном примере мы создадим форму с несколькими полями ввода, для формы зададим оранжевый цвет каретки, [`<input>`](/html/input/) будет наследовать свойство от формы, для [`<textarea>`](/html/textarea/) переопределим его на синий, а для параграфа с атрибутом [`contenteditable`](/html/global-attrs/) зададим розовый цвет каретки:
 
 ```html
 <form>
@@ -70,16 +63,16 @@ input {
 
 ```css
 form {
-  caret-color: #ff8630;
+  caret-color: #FF8630;
 }
 
 form textarea {
-  caret-color: #0d47a1;
+  caret-color: #2E9AFF;
 }
 
 form p {
-  caret-color: #00dd00;
+  caret-color: #F498AD;
 }
 ```
 
-<iframe title="Наследование и переопределение значения" src="demos/form/" height="330"></iframe>
+<iframe title="Наследование и переопределение значения" src="demos/form/" height="410"></iframe>

--- a/css/caret-color/index.md
+++ b/css/caret-color/index.md
@@ -3,6 +3,8 @@ title: "`caret-color`"
 description: "С помощью `caret-color` можно менять цвет курсора в режиме набора текста."
 authors:
   - mishamad
+contributors:
+  - starhamster
 related:
   - html/input
   - html/textarea

--- a/css/caret-color/practice/mishamad.md
+++ b/css/caret-color/practice/mishamad.md
@@ -6,25 +6,12 @@
 
 ```css
 @keyframes rainbow {
-  0% { caret-color: red; }
-  20% { caret-color: orange; }
-  40% { caret-color: yellow; }
-  60% { caret-color: green; }
-  80% { caret-color: blue; }
-  100% { caret-color: purple; }
-}
-
-input {
-  display: block;
-  width: 60vw;
-  height: 50px;
-  font-family: "Roboto", sans-serif;
-  font-size: 50px;
-  caret-color: red;
-  background-color: rgb(255 255 255 / 0.1);
-  color: #eee;
-  border-radius: 1rem;
-  border: 2px dotted rgb(255 255 255 / 0.1);
+  0% { caret-color: #F498AD; }
+  20% { caret-color: #FF8630; }
+  40% { caret-color: #FFD829; }
+  60% { caret-color: #41E847; }
+  80% { caret-color: #2E9AFF; }
+  100% { caret-color: #F498AD; }
 }
 
 input:focus {
@@ -32,4 +19,4 @@ input:focus {
 }
 ```
 
-<iframe title="Анимированная радужная каретка" src="../demos/rainbow-input/" height="330" sandbox></iframe>
+<iframe title="Анимированная радужная каретка" src="../demos/rainbow-input/" height="230"></iframe>


### PR DESCRIPTION
## Описание

Немного заредизайнил, убрал лишнее: плейсхолдеры в одной из демок (они полностью дублировали лейблы), автофокус в другой (он всё равно не работал в ифрейме). Немного почистил сниппеты от лишнего кода

Было:

![Screen Shot 2023-08-16 at 18 52 46](https://github.com/doka-guide/content/assets/91747573/60e1e981-3cd5-423f-8e06-9dd7bcc1995a)

Стало:

![Screen Shot 2023-08-16 at 18 53 04](https://github.com/doka-guide/content/assets/91747573/a92ae328-4352-48d0-9a70-cfe98bbb6f2d)

Было2:

![Screen Shot 2023-08-16 at 18 53 34](https://github.com/doka-guide/content/assets/91747573/bb26cd29-f1e5-43ab-8e46-9583ddeec02a)

Стало2:

![Screen Shot 2023-08-16 at 18 54 12](https://github.com/doka-guide/content/assets/91747573/014b3120-be11-494b-9993-f8b75e99abc1)

Было3:

![Screen Shot 2023-08-16 at 18 54 31](https://github.com/doka-guide/content/assets/91747573/27462f5f-8fdc-48cf-9d9a-aa83bc1af9b0)

Стало3:

![Screen Shot 2023-08-16 at 18 56 53](https://github.com/doka-guide/content/assets/91747573/1c484eed-b411-4c07-8124-c726fa53c7ba)

## Ссылка

https://content-4676.dev.doka.guide/css/caret-color/