### PR TITLE
Меняет ссылку в тексте Доки про background-image на правильную

### DIFF
--- a/css/background-image/index.md
+++ b/css/background-image/index.md
@@ -89,7 +89,7 @@ div {
 }
 ```
 
-Подробнее о градиентах можно прочитать в статьях о [`linear-gradient`](/css/line-height/), [`radial-gradient`](/css/radial-gradient/) и [`conic-gradient()`](/css/conic-gradient/).
+Подробнее о градиентах можно прочитать в статьях о [`linear-gradient`](/css/linear-gradient/), [`radial-gradient`](/css/radial-gradient/) и [`conic-gradient()`](/css/conic-gradient/).
 
 ## Подсказки
 


### PR DESCRIPTION
## Описание

<!-- Кратко опишите изменение -->

Closes #<!-- проставьте номер ишью, которое решает задача или удалите строку, если ишью нет -->

## Чек-лист

<!-- Список для самопроверки. Поможет вам подготовить пулреквест для быстрого мёрджа. Часть пунктов может быть неактуальна для вашей задачи, просто отметьте их как сделанные -->

- [x] Текст оформлен [согласно руководству по стилю](https://github.com/doka-guide/content/blob/main/docs/styleguide.md)
- [x] Ссылки на внутренние материалы начинаются со слеша и заканчиваются слэшем либо якорем на заголовок (`/css/color/`, `/tools/json/`, `/tools/gulp/#kak-ponyat`)
- [x] Ссылки на картинки, видео и демки относительные (`images/example.png`, `demos/example/`, `../demos/example/`)
