### PR TITLE
Исправляет ошибку в `На практике` для `will-change`

### DIFF
--- a/css/will-change/practice/madey-kv.md
+++ b/css/will-change/practice/madey-kv.md
@@ -59,7 +59,7 @@ const el = document.getElementById('element')
 
 // Включаем will-change при наведении курсора на элемент
 el.addEventListener('mouseenter', hintBrowser)
-el.addEventListener('animationEnd', removeHint)
+el.addEventListener('transitionend', removeHint)
 
 function hintBrowser() {
   // Свойства, которые будут изменяться в блоке


### PR DESCRIPTION
## Описание

В разделе `На практике` используется невалидный пример кода. События `animationEnd` не существует, но существует событие `animationend` ([подробнее](https://developer.mozilla.org/en-US/docs/Web/API/Element/animationend_event)).

Однако по контексту раздела больше подходит событие `transitionend`, потому что в примерах выше  [key frames](https://developer.mozilla.org/en-US/docs/Web/CSS/@keyframes) до этого не появлялись.

## Чек-лист

Изменения не затрагивают чек-лист

- [x] Текст оформлен [согласно руководству по стилю](https://github.com/doka-guide/content/blob/main/docs/styleguide.md)
- [x] Ссылки на внутренние материалы начинаются со слеша и заканчиваются слэшем либо якорем на заголовок (`/css/color/`, `/tools/json/`, `/tools/gulp/#kak-ponyat`)
- [x] Ссылки на картинки, видео и демки относительные (`images/example.png`, `demos/example/`, `../demos/example/`)
