### PR TITLE
Слегка причёсывает демки в `<embed>` и `<object>`

### DIFF
--- a/html/embed/demos/embed-pdf/index.html
+++ b/html/embed/demos/embed-pdf/index.html
@@ -5,6 +5,16 @@
   <meta charset="utf-8">
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <style>
+    *, *::before, *::after {
+      margin: 0;
+      padding: 0;
+      box-sizing: border-box;
+    }
+
+    html {
+      color-scheme: dark;
+    }
+
     html, body {
       height: 100%;
     }
@@ -12,13 +22,19 @@
     body {
       display: grid;
       place-items: center;
-      margin: 0;
+      padding: 50px;
       background-color: #18191C;
     }
 
     embed {
       width: 80%;
       height: 80%;
+    }
+
+    @media (max-width: 768px) {
+      body {
+        padding: 30px;
+      }
     }
   </style>
 </head>

--- a/html/embed/index.md
+++ b/html/embed/index.md
@@ -27,7 +27,7 @@ tags:
 <embed src="sample.pdf" type="application/pdf">
 ```
 
-<iframe title="Вставка PDF" src="demos/embed-pdf/" height="400"></iframe>
+<iframe title="Вставка PDF" src="demos/embed-pdf/" height="700"></iframe>
 
 ## Как понять
 

--- a/html/object/demos/show-pdf/index.html
+++ b/html/object/demos/show-pdf/index.html
@@ -6,12 +6,16 @@
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <link rel="preconnect" href="https://fonts.googleapis.com">
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
-  <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Roboto:wght@400;500&display=swap">
+  <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Roboto&display=swap">
   <style>
     *, *::before, *::after {
       margin: 0;
       padding: 0;
       box-sizing: border-box;
+    }
+
+    html {
+      color-scheme: dark;
     }
 
     body {
@@ -29,14 +33,14 @@
     a {
       border-radius: 3px;
       color: inherit;
-      -webkit-text-decoration-color: #2E9AFF;
-      text-decoration-color: #2E9AFF;
+      -webkit-text-decoration-color: #FF8630;
+      text-decoration-color: #FF8630;
       text-decoration-thickness: 2px;
       transition: background-color 0.2s linear;
     }
 
     a:hover, a:focus {
-      background-color: #2E9AFF;
+      background-color: #FF8630;
       transition: background-color 0.2s linear;
       outline-width: 0;
     }
@@ -50,11 +54,8 @@
 </head>
 <body>
   <div class="container">
-    <object type="application/pdf"
-        data="example.pdf"
-        width="500"
-        height="200">
-        <a href="example.pdf">Лунная соната №14 PDF</a>
+    <object type="application/pdf" data="example.pdf" width="600" height="700">
+      <a href="example.pdf">Лунная соната № 14 PDF</a>
     </object>
   </div>
 </body>

--- a/html/object/index.md
+++ b/html/object/index.md
@@ -26,7 +26,8 @@ tags:
   type="video/mp4"
   data="https://www.youtube.com/watch?v=dQw4w9WgXcQ"
   width="1280"
-  height="720">
+  height="720"
+>
 </object>
 ```
 
@@ -35,15 +36,18 @@ tags:
 ## Как пишется
 
 ```html
-<object class="pdf_example" type="application/pdf"
+<object
+  class="pdf_example"
+  type="application/pdf"
   data="example.pdf"
-  width="300"
-  height="200">
+  width="600"
+  height="700"
+>
   <a href="example.pdf">Лунная соната №14 PDF</a>
 </object>
 ```
 
-<iframe title="Встроенный pdf с помощью <object>" src="./demos/show-pdf/" height="310"></iframe>
+<iframe title="Встроенный с помощью object pdf-файл" src="./demos/show-pdf/" height="830"></iframe>
 
 Если браузер не поддерживает тип встроенного файла, то он покажет вложенное содержимое в качестве фолбэка. В нашем примере, если встраивание PDF-инструкции не поддерживается, то мы увидим ссылку на её скачивание.
 
@@ -52,7 +56,7 @@ tags:
 - `data` — ссылка на встраиваемый ресурс;
 - `type` — MIME-тип подгружаемого объекта;
 - `name` — имя объекта;
-- `usemap` — атрибут для связи объекта с тегом `<map>`;
+- `usemap` — атрибут для связи объекта с [тегом `<map>`](/html/map/);
 - `width` — ширина объекта;
 - `height` — высота объекта;
 - `form` — связь с одной или несколькими формами.

--- a/html/object/index.md
+++ b/html/object/index.md
@@ -43,11 +43,11 @@ tags:
   width="600"
   height="700"
 >
-  <a href="example.pdf">Лунная соната №14 PDF</a>
+  <a href="example.pdf">Лунная соната № 14 PDF</a>
 </object>
 ```
 
-<iframe title="Встроенный с помощью object pdf-файл" src="./demos/show-pdf/" height="830"></iframe>
+<iframe title="Встроенный с помощью object pdf-файл" src="demos/show-pdf/" height="830"></iframe>
 
 Если браузер не поддерживает тип встроенного файла, то он покажет вложенное содержимое в качестве фолбэка. В нашем примере, если встраивание PDF-инструкции не поддерживается, то мы увидим ссылку на её скачивание.
 


### PR DESCRIPTION
## Описание

Поменяла высоту фреймов и добавила недостающие стили. Так что внешне ничего особо не поменялось. Там и так всё хорошо. Ещё добавила ссылку на другую доку и отформатировала и обновила пример кода в `<object>`.

https://doka.guide/html/object/ → https://content-4744.dev.doka.guide/html/object/
https://doka.guide/html/embed/ → https://content-4744.dev.doka.guide/html/embed/

## Чек-лист

<!-- Список для самопроверки. Поможет вам подготовить пулреквест для быстрого мёрджа. Часть пунктов может быть неактуальна для вашей задачи, просто отметьте их как сделанные -->

- [x] Текст оформлен [согласно руководству по стилю](https://github.com/doka-guide/content/blob/main/docs/styleguide.md)
- [x] Ссылки на внутренние материалы начинаются со слеша и заканчиваются слэшем либо якорем на заголовок (`/css/color/`, `/tools/json/`, `/tools/gulp/#kak-ponyat`)
- [x] Ссылки на картинки, видео и демки относительные (`images/example.png`, `demos/example/`, `../demos/example/`)
