### PR TITLE
Причёсывает демки и дополняет доку «Атрибут `disabled`»

### DIFF
--- a/html/disabled/demos/base/images/arrow-down.svg
+++ b/html/disabled/demos/base/images/arrow-down.svg
@@ -1,0 +1,3 @@
+<svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 14 9">
+  <path fill="#FFFFFF" d="M7 5.59L11.59 1A1 1 0 1113 2.41l-6 6-6-6A1 1 0 012.41 1L7 5.59z"/>
+</svg>

--- a/html/disabled/demos/base/index.html
+++ b/html/disabled/demos/base/index.html
@@ -6,12 +6,17 @@
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <link rel="preconnect" href="https://fonts.googleapis.com">
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
-  <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Roboto&display=swap">
+  <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Roboto:wght@300;400;500&display=swap">
   <style>
     *, *::before, *::after {
       margin: 0;
       padding: 0;
       box-sizing: border-box;
+    }
+
+    html {
+      color-scheme: dark;
+      font-size: 18px;
     }
 
     html, body {
@@ -24,9 +29,8 @@
       justify-content: center;
       padding: 50px 15px;
       font-family: "Roboto", sans-serif;
-      font-size: 24px;
-      color: #ffffff;
-      accent-color: darkmagenta;
+      color: #FFFFFF;
+      accent-color: #FF8630;
       background-color: #18191c;
     }
 
@@ -35,75 +39,190 @@
       flex-wrap: wrap;
       gap: 25px;
       width: 100%;
-      max-width: 650px;
+      max-width: 700px;
       margin: 0 auto;
-      padding: 10px;
-      border: 1px solid #683612;
+      padding: 20px;
+      border: 1px solid #FFFFFF;
     }
 
     div:not(:last-child) {
       margin-bottom: 30px;
     }
 
-    button,
-    input,
-    textarea,
-    select {
-      font: inherit;
+    button, input, textarea, select {
+      font-size: 1rem;
+      font-family: inherit;
     }
 
-    button,
-    fieldset,
-    select,
-    textarea {
+    button {
+      display: block;
+      min-width: 210px;
+      border: 2px solid transparent;
+      border-radius: 6px;
+      padding: 9px 15px;
+      color: #000000;
+      font-weight: 300;
+      transition: background-color 0.2s linear;
+    }
+
+    .button-orange {
+      background-color: #FF8630;
+    }
+
+    button:hover {
+      background-color: #FFFFFF;
+      cursor: pointer;
+      transition: background-color 0.2s linear;
+    }
+
+    button:focus-visible {
+      border: 2px solid #FFFFFF;
+      outline: none;
+    }
+
+    button:focus {
+      border: 2px solid #FFFFFF;
+      outline: none;
+    }
+
+    fieldset, select, textarea {
       padding: 10px 15px;
     }
 
     fieldset {
       flex: 1 1 45%;
+      margin: 0;
+      padding: 0;
+      border: 0;
     }
 
-    [disabled] {
-      color: #999999;
-      background-color: darkslategray;
+    .fieldset-item {
+      display: flex;
+      justify-content: space-between;
+      align-items: center;
+    }
+
+    .fieldset-item + .fieldset-item {
+      margin-top: 25px;
+    }
+
+    .fieldset-label {
+      margin-right: 10px;
+      font-size: 1rem;
+      font-weight: 500;
+      line-height: 1;
+    }
+
+    input {
+      border: 1px solid #FFFFFF;
+      border-radius: 6px;
+      padding: 10px 8px;
+      background-color: transparent;
+      color: #FFFFFF;
+      font-size: 1rem;
+      font-weight: 300;
+      font-family: inherit;
+      -webkit-appearance: none;
+      appearance: none;
+    }
+
+    input:focus {
+      border-color: #FF8630;
+      outline: none;
+    }
+
+    textarea {
+      min-width: 300px;
+      max-width: 300px;
+      min-height: 100px;
+      max-height: 300px;
+      border: 1px solid #FFFFFF;
+      border-radius: 6px;
+      padding: 10px 15px;
+      background-color: transparent;
+      color: #FFFFFF;
+      font-size: 18px;
+      font-weight: 300;
+      font-family: inherit;
+    }
+
+    textarea:focus {
+      border-color: #FF8630;
+      outline: none;
+    }
+
+    .checkbox-item {
+      position: relative;
+      display: flex;
+      align-items: center;
+      cursor: pointer;
     }
 
     input[type="checkbox"] {
-      width: 25px;
-      height: 25px;
-      vertical-align: text-bottom;
+      width: 24px;
+      height: 24px;
+      opacity: 0;
+      margin-right: 15px;
     }
 
-    fieldset > label:not(:last-child) {
-      display: block;
-      margin-bottom: 20px;
+    input[type="checkbox"] + .checkbox-label::before {
+      content: '';
+      position: absolute;
+      left: 0;
+      top: calc(50% - 12px);
+      width: 24px;
+      height: 24px;
+      border: 1px solid #FFFFFF;
+      border-radius: 6px;
+    }
+
+    input[type="checkbox"]:focus + .checkbox-label::before {
+      border-color: #FF8630;
+    }
+
+    input[type="checkbox"]:checked + .checkbox-label::after {
+      content: '';
+      position: absolute;
+      left: 5px;
+      top: calc(50% - 7px);
+      width: 14px;
+      height: 14px;
+      border-radius: 3px;
+      background-color: #FF8630;
+    }
+
+    [disabled], .checkbox-item--inactive {
+      opacity: 0.7;
+      pointer-events: none;
+      cursor: default;
+      user-select: none;
     }
   </style>
 </head>
 <body>
   <div>
-    <button>Кнопка</button>
-    <button disabled>Кнопка</button>
+    <button class="button-orange">Подтвердить</button>
+    <button class="button-orange" disabled>Подтвердить</button>
   </div>
   <div>
     <fieldset>
-      <label>
-        Ваше имя
+      <label class="fieldset-item">
+        <span class="fieldset-label">Имя:</span>
         <input type="text">
       </label>
-      <label>
-        Ваш телефон
-        <input type="text">
+      <label class="fieldset-item">
+        <span class="fieldset-label">Телефон:</span>
+        <input type="tel">
       </label>
     </fieldset>
     <fieldset disabled>
-      <label>
-        Ваше имя
+      <label class="fieldset-item">
+        <span class="fieldset-label">Имя:</span>
         <input type="text">
       </label>
-      <label>
-        Ваш телефон
-        <input type="text">
+      <label class="fieldset-item">
+        <span class="fieldset-label">Телефон:</span>
+        <input type="tel">
       </label>
     </fieldset>
   </div>
@@ -144,13 +263,13 @@
     <textarea disabled>Некий текст</textarea>
   </div>
   <div>
-    <label>
-      Подтверждаю
+    <label class="checkbox-item">
       <input type="checkbox">
+      <span class="checkbox-label">Подтверждаю</span>
     </label>
-    <label>
-      Подтверждаю
+    <label class="checkbox-item checkbox-item--inactive">
       <input type="checkbox" disabled>
+      <span class="checkbox-label">Подтверждаю</span>
     </label>
   </div>
 </body>

--- a/html/disabled/demos/base/index.html
+++ b/html/disabled/demos/base/index.html
@@ -27,7 +27,7 @@
       display: flex;
       flex-direction: column;
       justify-content: center;
-      padding: 50px 15px;
+      padding: 50px;
       font-family: "Roboto", sans-serif;
       color: #FFFFFF;
       accent-color: #FF8630;
@@ -42,7 +42,6 @@
       max-width: 700px;
       margin: 0 auto;
       padding: 20px;
-      border: 1px solid #FFFFFF;
     }
 
     div:not(:last-child) {
@@ -83,10 +82,6 @@
     button:focus {
       border: 2px solid #FFFFFF;
       outline: none;
-    }
-
-    fieldset, select, textarea {
-      padding: 10px 15px;
     }
 
     fieldset {
@@ -141,7 +136,7 @@
       padding: 10px 15px;
       background-color: transparent;
       color: #FFFFFF;
-      font-size: 18px;
+      font-size: 1rem;
       font-weight: 300;
       font-family: inherit;
     }
@@ -191,11 +186,83 @@
       background-color: #FF8630;
     }
 
+    select {
+      position: relative;
+      width: 300px;
+      border: 1px solid #FFFFFF;
+      border-radius: 6px;
+      padding: 10px 15px;
+      background-color: #18191C;
+      color: #FFFFFF;
+      font-family: inherit;
+      font-size: inherit;
+      font-weight: 300;
+      cursor: pointer;
+      -webkit-appearance: none;
+      appearance: none;
+    }
+
+    .select-container {
+      position: relative;
+    }
+
+    .select-container::after {
+      content: "";
+      position: absolute;
+      top: calc(50% - 4px);
+      left: 295px;
+      width: 14px;
+      height: 9px;
+      background-image: url("images/arrow-down.svg");
+      background-repeat: no-repeat;
+      background-position: center;
+      background-size: 100%;
+      pointer-events: none;
+    }
+
+    select:focus {
+      outline: none;
+      border: 1px solid #FF8630;
+    }
+
+    option {
+      font-weight: inherit;
+      font-family: inherit;
+      font-size: inherit;
+    }
+
+    option:checked {
+      background-color: #FF8630;
+      color: #18191C;
+    }
+
     [disabled], .checkbox-item--inactive {
-      opacity: 0.7;
+      opacity: 0.6;
       pointer-events: none;
       cursor: default;
       user-select: none;
+    }
+
+    @media (max-width: 780px) {
+      body {
+        padding: 30px;
+      }
+
+      div, input {
+        width: 100%;
+      }
+
+      textarea {
+        min-width: 100%;
+      }
+
+      .fieldset-item {
+        display: block;
+      }
+
+      input {
+        margin-top: 10px;
+      }
     }
   </style>
 </head>
@@ -226,7 +293,7 @@
       </label>
     </fieldset>
   </div>
-  <div>
+  <div class="select-container">
     <select name="flowers">
       <optgroup>
         <option value="Незабудка">Незабудка</option>
@@ -238,7 +305,7 @@
       </optgroup>
     </select>
   </div>
-  <div>
+  <div class="select-container">
     <select name="flowers">
       <option value="Незабудка">Незабудка</option>
       <option value="Подснежник">Подснежник</option>
@@ -246,16 +313,12 @@
       <option value="Хризантемы" disabled>Хризантемы</option>
     </select>
   </div>
-  <div>
+  <div class="select-container">
     <select name="flowers" disabled>
-      <optgroup>
-        <option value="Незабудка">Незабудка</option>
-        <option value="Подснежник">Подснежник</option>
-      </optgroup>
-      <optgroup>
-        <option value="Анютины глазки">Анютины глазки</option>
-        <option value="Хризантемы">Хризантемы</option>
-      </optgroup>
+      <option value="Незабудка">Незабудка</option>
+      <option value="Подснежник">Подснежник</option>
+      <option value="Анютины глазки">Анютины глазки</option>
+      <option value="Хризантемы">Хризантемы</option>
     </select>
   </div>
   <div>

--- a/html/disabled/index.md
+++ b/html/disabled/index.md
@@ -46,7 +46,7 @@ tags:
 - [`<textarea>`](/html/textarea/);
 - [`<input>`](/html/input/).
 
-<iframe title="Примеры использования" src="demos/base/" height="700"></iframe>
+<iframe title="Примеры использования" src="demos/base/" height="1000"></iframe>
 
 ## Как понять
 

--- a/html/disabled/index.md
+++ b/html/disabled/index.md
@@ -3,6 +3,8 @@ title: "Атрибут `disabled`"
 description: "Если у элемента формы есть этот атрибут, то с ним нельзя взаимодействовать."
 authors:
   - solarrust
+contributors:
+  - tatianafokina
 related:
   - html/global-attrs
   - css/disabled-enabled
@@ -47,6 +49,12 @@ tags:
 - [`<input>`](/html/input/).
 
 <iframe title="Примеры использования" src="demos/base/" height="1000"></iframe>
+
+### Доступность
+
+В [ARIA](/a11y/aria-intro/) есть атрибут [`aria-disabled`](/a11y/aria-disabled/). Он тоже указывает на то, что элемент нельзя изменить или взаимодействовать с ним другим способом.
+
+Старайтесь использовать `disabled`. `aria-disabled` поможет в сложных ситуациях, когда создаёте кастомные элементы.
 
 ## Как понять
 

--- a/html/disabled/index.md
+++ b/html/disabled/index.md
@@ -22,12 +22,12 @@ tags:
 ```html
 <fieldset disabled>
   <label>
-    Ваше имя
+    Имя:
     <input type="text">
   </label>
   <label>
-    Ваш номер телефона
-    <input type="text">
+    Телефон:
+    <input type="tel">
   </label>
 </fieldset>
 ```
@@ -46,7 +46,7 @@ tags:
 - [`<textarea>`](/html/textarea/);
 - [`<input>`](/html/input/).
 
-<iframe title="Примеры использования" src="demos/base/" height="510"></iframe>
+<iframe title="Примеры использования" src="demos/base/" height="700"></iframe>
 
 ## Как понять
 


### PR DESCRIPTION
## Описание

Добавила для демки фирменный стиль и немного рассказала про аналог атрибута в ARIA.

https://doka.guide/html/disabled/ → https://content-4749.dev.doka.guide/html/disabled/

## Чек-лист

<!-- Список для самопроверки. Поможет вам подготовить пулреквест для быстрого мёрджа. Часть пунктов может быть неактуальна для вашей задачи, просто отметьте их как сделанные -->

- [x] Текст оформлен [согласно руководству по стилю](https://github.com/doka-guide/content/blob/main/docs/styleguide.md)
- [x] Ссылки на внутренние материалы начинаются со слеша и заканчиваются слэшем либо якорем на заголовок (`/css/color/`, `/tools/json/`, `/tools/gulp/#kak-ponyat`)
- [x] Ссылки на картинки, видео и демки относительные (`images/example.png`, `demos/example/`, `../demos/example/`)
