### PR TITLE
Обновляет демки в «Атрибут `multiple`»

### DIFF
--- a/html/multiple/demos/basic/index.html
+++ b/html/multiple/demos/basic/index.html
@@ -14,35 +14,45 @@
       box-sizing: border-box;
     }
 
+    html {
+      color-scheme: dark;
+      font-size: 18px;
+    }
+
     body {
+      min-height: 100vh;
+      padding: 50px;
       display: flex;
       align-items: center;
       justify-content: center;
-      min-height: 100vh;
-      padding: 100px 50px;
-      background-color: #18191c;
-      color: #ffffff;
+      background-color: #18191C;
+      color: #FFFFFF;
       font-family: "Roboto", sans-serif;
-      font-size: 18px;
+    }
+
+    .container {
+      display: flex;
+      align-items: center;
+      justify-content: space-between;
     }
 
     .select-label {
       display: block;
-      font-size: 24px;
+      font-size: 1.5rem;
       font-weight: 500;
       margin-right: 35px;
     }
 
     .select {
       position: relative;
-      width: 400px;
-      border: 1px solid #ffffff;
+      width: 300px;
+      border: 1px solid #FFFFFF;
       border-radius: 6px;
-      padding: 8px 15px;
-      background-color: #18191c;
-      color: #ffffff;
+      padding: 10px 15px;
+      background-color: transparent;
+      color: #FFFFFF;
       font-family: inherit;
-      font-size: inherit;
+      font-size: 1rem;
       font-weight: 300;
       cursor: pointer;
       -webkit-appearance: none;
@@ -63,18 +73,34 @@
       font-family: inherit;
       font-size: inherit;
     }
+
+    @media (max-width: 768px) {
+      body {
+        padding: 30px;
+      }
+
+      .container {
+        display: block;
+      }
+
+      .select-wrapper {
+        margin-top: 10px;
+      }
+    }
   </style>
 </head>
 <body>
-  <label class="select-label" for="city-select">Лишнее слово</label>
-  <div class="select-wrapper">
-    <select class="select" id="city-select" size="5" multiple>
-      <option>Красный</option>
-      <option>Классный</option>
-      <option>Зелёный</option>
-      <option>Синий</option>
-      <option>Съел иней</option>
-    </select>
+  <div class="container">
+    <label class="select-label" for="city-select">Лишнее слово:</label>
+    <div class="select-wrapper">
+      <select class="select" id="city-select" size="5" multiple>
+        <option>Красный</option>
+        <option>Классный</option>
+        <option>Зелёный</option>
+        <option>Синий</option>
+        <option>Съел иней</option>
+      </select>
+    </div>
   </div>
 </body>
 </html>

--- a/html/multiple/demos/multiple-input-email/index.html
+++ b/html/multiple/demos/multiple-input-email/index.html
@@ -79,7 +79,7 @@
 </head>
 <body>
   <div class="container">
-    <label class="input-label" for="emails">Выберите почтовые адреса:</label>
+    <label class="input-label" for="emails">Выберите почту:</label>
     <input class="input" type="email" id="emails" list="list-of-emails" size="60" multiple>
     <datalist id="list-of-emails">
       <option value="nekto@doka.guide">Неизвестный</option>

--- a/html/multiple/demos/multiple-input-email/index.html
+++ b/html/multiple/demos/multiple-input-email/index.html
@@ -1,12 +1,12 @@
 <!DOCTYPE html>
 <html lang="ru">
 <head>
-  <title>Использование атрибута multiple для множественного выбора имейлов — Атрибут multiple — Дока</title>
+  <title>Множественный выбор почтовых адресов — Атрибут multiple — Дока</title>
   <meta charset="utf-8">
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <link rel="preconnect" href="https://fonts.googleapis.com">
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
-  <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Roboto+Mono:wght@400;500&display=swap">
+  <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Roboto:wght@300;400;500&display=swap">
   <style>
     *, *::before, *::after {
       margin: 0;
@@ -14,36 +14,38 @@
       box-sizing: border-box;
     }
 
-    body {
-      display: flex;
-      align-items: center;
-      justify-content: center;
-      min-height: 100vh;
-      padding: 100px 50px;
-      background-color: #18191c;
-      color: #ffffff;
-      font-family: "Roboto Mono", monospace;
+    html {
+      color-scheme: dark;
       font-size: 18px;
     }
 
-    .input-label {
-      display: block;
-      font-size: 24px;
-      font-weight: 500;
-      margin-right: 35px;
+    body {
+      min-height: 100vh;
+      padding: 50px;
+      display: flex;
+      align-items: center;
+      justify-content: center;
+      background-color: #18191C;
+      color: #FFFFFF;
+      font-family: "Roboto", sans-serif;
+    }
+
+    .container {
+      display: flex;
+      justify-content: space-between;
+      align-items: center;
     }
 
     .input {
-      position: relative;
-      border: 1px solid #ffffff;
+      width: 300px;
+      border: 1px solid #FFFFFF;
       border-radius: 6px;
-      padding: 5px 15px;
-      background-color: #18191c;
-      color: #ffffff;
-      font-family: inherit;
-      font-size: inherit;
+      padding: 10px 15px;
+      background-color: transparent;
+      color: #FFFFFF;
+      font-size: 1rem;
       font-weight: 300;
-      cursor: pointer;
+      font-family: inherit;
       -webkit-appearance: none;
       appearance: none;
     }
@@ -52,19 +54,42 @@
       outline: none;
       border: 1px solid #ff8630;
     }
+
+    .input-label {
+      display: block;
+      font-size: 1.5rem;
+      font-weight: 500;
+      margin-right: 35px;
+    }
+
+    @media (max-width: 768px) {
+      body {
+        padding: 30px;
+      }
+
+      .container {
+        display: block;
+      }
+
+      .input {
+        margin-top: 10px;
+      }
+    }
   </style>
 </head>
 <body>
-  <label class="input-label" for="emails">Выберите имейлы</label>
-  <input class="input" type="email" id="emails" list="list-of-emails" size="60" multiple>
-  <datalist id="list-of-emails">
-    <option value="nekto@doka.guide">Неизвестный</option>
-    <option value="prikolist333@doka.guide">Друг шутник</option>
-    <option value="anderyBoss@doka.guide">Босс Андрей</option>
-    <option value="grish111a@doka.guide">Просто Гриша</option>
-    <option value="brigadir@doka.guide">Бригадир</option>
-    <option value="s0123tr1012dgs@doka.guide">Не знаю кто</option>
-    <option value="printerDanila01@doka.guide">Почта для принтера</option>
-  </datalist>
+  <div class="container">
+    <label class="input-label" for="emails">Выберите почтовые адреса:</label>
+    <input class="input" type="email" id="emails" list="list-of-emails" size="60" multiple>
+    <datalist id="list-of-emails">
+      <option value="nekto@doka.guide">Неизвестный</option>
+      <option value="prikolist333@doka.guide">Друг шутник</option>
+      <option value="anderyBoss@doka.guide">Босс Андрей</option>
+      <option value="grish111a@doka.guide">Просто Гриша</option>
+      <option value="brigadir@doka.guide">Бригадир</option>
+      <option value="s0123tr1012dgs@doka.guide">Не знаю кто</option>
+      <option value="printerDanila01@doka.guide">Почта для принтера</option>
+    </datalist>
+  </div>
 </body>
 </html>

--- a/html/multiple/demos/multiple-input-files/index.html
+++ b/html/multiple/demos/multiple-input-files/index.html
@@ -1,12 +1,12 @@
 <!DOCTYPE html>
 <html lang="ru">
 <head>
-  <title>Использование атрибута multiple для множественного выбора файлов — Атрибут multiple — Дока</title>
+  <title>Множественный выбор файлов — Атрибут multiple — Дока</title>
   <meta charset="utf-8">
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <link rel="preconnect" href="https://fonts.googleapis.com">
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
-  <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Roboto+Mono:wght@400;500&display=swap">
+  <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Roboto:wght@300;400&display=swap">
   <style>
     *, *::before, *::after {
       margin: 0;
@@ -14,48 +14,70 @@
       box-sizing: border-box;
     }
 
-    body {
-      display: flex;
-      align-items: center;
-      justify-content: center;
-      min-height: 100vh;
-      padding: 100px 50px;
-      background-color: #18191c;
-      color: #ffffff;
-      font-family: "Roboto Mono", monospace;
+    html {
+      color-scheme: dark;
       font-size: 18px;
     }
 
-    .input-label {
+    body {
+      min-height: 100vh;
+      padding: 50px;
+      display: flex;
+      align-items: center;
+      justify-content: center;
+      background-color: #18191C;
+      color: #FFFFFF;
+      font-family: "Roboto", sans-serif;
+    }
+
+    @media (max-width: 768px) {
+      body {
+        padding: 30px;
+      }
+    }
+
+    .input__button::file-selector-button {
       display: block;
-      font-size: 24px;
-      font-weight: 500;
-      margin-right: 35px;
-    }
-
-    .input {
-      position: relative;
-      border: 1px solid #ffffff;
+      min-width: 210px;
+      border: 2px solid transparent;
       border-radius: 6px;
-      padding: 5px 15px;
-      background-color: #18191c;
-      color: #ffffff;
-      font-family: inherit;
-      font-size: inherit;
+      padding: 9px 15px;
+      margin-bottom: 15px;
+      color: #000000;
+      font-size: 1rem;
       font-weight: 300;
+      font-family: inherit;
+      text-align: center;
+      transition: background-color 0.2s linear;
+      --webkit-user-select: none;
       cursor: pointer;
-      -webkit-appearance: none;
-      appearance: none;
     }
 
-    .input:focus {
+    .input__button--orange::file-selector-button {
+      background-color: #FF8630;
+    }
+
+    .input__button::file-selector-button:hover {
+      background-color: #FFFFFF;
+      cursor: pointer;
+      transition: background-color 0.2s linear;
+    }
+
+    .input__button:focus,
+    .input__button:focus-visible {
       outline: none;
-      border: 1px solid #ff8630;
+    }
+
+    .input__button:focus-visible::file-selector-button {
+      border: 2px solid #FFFFFF;
+    }
+
+    .input__button:focus::file-selector-button {
+      border: 2px solid #FFFFFF;
     }
   </style>
 </head>
 <body>
-  <label class="input-label" for="files">Выберите файлы</label>
-  <input class="input" type="file" id="files" multiple>
+  <input class="input__button input__button--orange" type="file" multiple>
 </body>
 </html>

--- a/html/multiple/index.md
+++ b/html/multiple/index.md
@@ -70,6 +70,6 @@ tags:
 
 ### Доступность
 
-В [ARIA](/a11y/aria-intro/) есть атрибут [`aria-multiselectable`](/a11y/aria-multiselectable/). Он тоже нужен для выбора нескольких опций из выпадающего списка или файлов.
+В [ARIA](/a11y/aria-intro/) есть атрибут [`aria-multiselectable`](/a11y/aria-multiselectable/). Он тоже нужен для выбора нескольких опций или файлов.
 
 Старайтесь всегда использовать `multiple`. `aria-multiselectable` поможет в сложных ситуациях, когда создаёте кастомные элементы.

--- a/html/multiple/index.md
+++ b/html/multiple/index.md
@@ -3,6 +3,8 @@ title: "Атрибут `multiple`"
 description: "Позволяет выбрать несколько значений или файлов."
 authors:
   - inventoris
+contributors:
+  - tatianafokina
 keywords:
   - множественный выбор
 related:
@@ -31,7 +33,7 @@ tags:
 </select>
 ```
 
-<iframe title="Базовый пример" src="demos/basic/" height="350"></iframe>
+<iframe title="Базовый пример" src="demos/basic/" height="300"></iframe>
 
 ## Как пишется
 
@@ -56,7 +58,7 @@ tags:
 </datalist>
 ```
 
-<iframe title="Использование атрибута multiple для множественного выбора имейлов" src="demos/multiple-input-email/" height="200"></iframe>
+<iframe title="Множественный выбор имейлов" src="demos/multiple-input-email/" height="300"></iframe>
 
 Создадим `<input>` с атрибутом `multiple`, но теперь для возможности закачать несколько файлов.
 
@@ -64,4 +66,10 @@ tags:
 <input type="file" multiple>
 ```
 
-<iframe title="Использование атрибута multiple для множественного выбора файлов" src="demos/multiple-input-files/" height="200"></iframe>
+<iframe title="Множественный выбор файлов" src="demos/multiple-input-files/" height="210"></iframe>
+
+### Доступность
+
+В [ARIA](/a11y/aria-intro/) есть атрибут [`aria-multiselectable`](/a11y/aria-multiselectable/). Он тоже нужен для выбора нескольких опций из выпадающего списка или файлов.
+
+Старайтесь всегда использовать `multiple`. `aria-multiselectable` поможет в сложных ситуациях, когда создаёте кастомные элементы.


### PR DESCRIPTION
## Описание

Сделала демки «фирменными» и добавила немного инфы про аналог в ARIA.

https://doka.guide/html/multiple/ → https://content-4750.dev.doka.guide/html/multiple/

## Чек-лист

<!-- Список для самопроверки. Поможет вам подготовить пулреквест для быстрого мёрджа. Часть пунктов может быть неактуальна для вашей задачи, просто отметьте их как сделанные -->

- [x] Текст оформлен [согласно руководству по стилю](https://github.com/doka-guide/content/blob/main/docs/styleguide.md)
- [x] Ссылки на внутренние материалы начинаются со слеша и заканчиваются слэшем либо якорем на заголовок (`/css/color/`, `/tools/json/`, `/tools/gulp/#kak-ponyat`)
- [x] Ссылки на картинки, видео и демки относительные (`images/example.png`, `demos/example/`, `../demos/example/`)
