### PR TITLE
Исправляет неправильное название функции в .removeEventListener()

### DIFF
--- a/js/element-removeeventlistener/practice/windrushfarer.md
+++ b/js/element-removeeventlistener/practice/windrushfarer.md
@@ -37,5 +37,5 @@ function handleKeypress(event) {
   }
 }
 
-window.addEventListener('keypress', handleClick)
+window.addEventListener('keypress', handleKeypress)
 ```


### PR DESCRIPTION
## Описание

<!-- Кратко опишите изменение -->

Исправляет неправильное название функции в .removeEventListener() для обработчика события клавиатуры в разделе "На практике"   

Closes #4732

## Чек-лист

<!-- Список для самопроверки. Поможет вам подготовить пулреквест для быстрого мёрджа. Часть пунктов может быть неактуальна для вашей задачи, просто отметьте их как сделанные -->

- [x] Текст оформлен [согласно руководству по стилю](https://github.com/doka-guide/content/blob/main/docs/styleguide.md)
- [x] Ссылки на внутренние материалы начинаются со слеша и заканчиваются слэшем либо якорем на заголовок (`/css/color/`, `/tools/json/`, `/tools/gulp/#kak-ponyat`)
- [x] Ссылки на картинки, видео и демки относительные (`images/example.png`, `demos/example/`, `../demos/example/`)
