### PR TITLE
Исправляет опечатку в разделе "Составной селектор в состоянии :active"

### DIFF
--- a/css/active/index.md
+++ b/css/active/index.md
@@ -71,7 +71,7 @@ a:active {
 ### Составной селектор в состоянии `:active`
 
 ```css
-li .link:focus {
+li .link:active {
   /* Стили */
 }
 ```


### PR DESCRIPTION
## Описание

Исправляет опечатку в разделе "Составной селектор в состоянии :active". В примере написано ":focus" вместо ":active"

## Чек-лист

<!-- Список для самопроверки. Поможет вам подготовить пулреквест для быстрого мёрджа. Часть пунктов может быть неактуальна для вашей задачи, просто отметьте их как сделанные -->

- [x] Текст оформлен [согласно руководству по стилю](https://github.com/doka-guide/content/blob/main/docs/styleguide.md)
- [x] Ссылки на внутренние материалы начинаются со слеша и заканчиваются слэшем либо якорем на заголовок (`/css/color/`, `/tools/json/`, `/tools/gulp/#kak-ponyat`)
- [x] Ссылки на картинки, видео и демки относительные (`images/example.png`, `demos/example/`, `../demos/example/`)
