### PR TITLE
Правит статью autocomplete

### DIFF
--- a/html/autocomplete/index.md
+++ b/html/autocomplete/index.md
@@ -27,7 +27,7 @@ tags:
 <form action="">
   <div>
     <label for="name">Введите имя</label>
-    <input id="name" type="text">
+    <input id="name" type="text" autocomplete="off">
   </div>
   <div>
     <label for="email">Электронная почта</label>


### PR DESCRIPTION
* Добавляет autocomplete="off", так как он по умолчанию всегда "on"

## Описание

В статье написано "Создадим форму, в которую пользователь будет сам вводить имя, а при заполнении поля e-mail сможет выбрать адрес почты из предложенных браузером вариантов:" после чего ставиться autocomplete="on" у поля e-mail, но ведь у имени тоже по умолчанию будет autocomplete="on", то есть тоже "сможет выбрать из предложенных браузером вариантов"
