### PR TITLE
Скрывает от скринридеров невидимый визуально блок с уведомлением

### DIFF
--- a/a11y/live-region/demos/toast-notification/index.html
+++ b/a11y/live-region/demos/toast-notification/index.html
@@ -102,6 +102,7 @@
       color: #000000;
       background-color: #FFFFFF;
       opacity: 0;
+      visibility: hidden;
       transform: translateY(0);
       transition:
         transform .2s ease-in-out,
@@ -110,6 +111,7 @@
 
     .toast.toast--open {
       opacity: 1;
+      visibility: visible;
       transform: translateY(-4em);
     }
 


### PR DESCRIPTION
В статье ["Что такое изменяющаяся область"](https://doka.guide/a11y/live-region/) в [демке c уведомлениями](https://doka.guide/a11y/live-region/demos/toast-notification/) сам блок с уведомлением виден скринридерам, из-за чего они читают кнопку "Закрыть".