### PR TITLE
Исправляет стили для иконки facebook'а в демо

### DIFF
--- a/html/svg-sprite/demos/sprite/index.html
+++ b/html/svg-sprite/demos/sprite/index.html
@@ -67,18 +67,18 @@
       transition: fill 0.3s ease-in-out;
     }
 
-    .sprite-demo__btn:has(.sprite-demo__social-icon_vk):hover .sprite-demo__social-icon_vk,
-    .sprite-demo__btn:has(.sprite-demo__social-icon_vk):focus .sprite-demo__social-icon_vk {
+    .sprite-demo__btn:hover .sprite-demo__social-icon_vk,
+    .sprite-demo__btn:focus .sprite-demo__social-icon_vk {
       fill: rgb(76 117 163);
     }
 
-    .sprite-demo__btn:has(.sprite-demo__social-icon_twitter):hover .sprite-demo__social-icon_twitter,
-    .sprite-demo__btn:has(.sprite-demo__social-icon_twitter):focus .sprite-demo__social-icon_twitter {
+    .sprite-demo__btn:hover .sprite-demo__social-icon_twitter,
+    .sprite-demo__btn:focus .sprite-demo__social-icon_twitter {
       fill: rgb(29 161 242);
     }
 
-    .sprite-demo__btn:has(.sprite-demo__social-icon_facebook):hover .sprite-demo__social-icon_facebook,
-    .sprite-demo__btn:has(.sprite-demo__social-icon_facebook):focus .sprite-demo__social-icon_facebook {
+    .sprite-demo__btn:hover .sprite-demo__social-icon_facebook,
+    .sprite-demo__btn:focus .sprite-demo__social-icon_facebook {
       fill: rgb(66 103 178);
     }
 

--- a/html/svg-sprite/demos/sprite/index.html
+++ b/html/svg-sprite/demos/sprite/index.html
@@ -79,7 +79,7 @@
 
     .sprite-demo__btn:has(.sprite-demo__social-icon_facebook):hover .sprite-demo__social-icon_facebook,
     .sprite-demo__btn:has(.sprite-demo__social-icon_facebook):focus .sprite-demo__social-icon_facebook {
-      fill: rgb(66 103, 178);
+      fill: rgb(66 103 178);
     }
 
     @media (max-width: 768px) {


### PR DESCRIPTION
## Описание

В материале про svg-спрайты есть демо (`html/svg-sprite/demos/sprite`), в котором не применялись стили для иконки facebook'а (`.sprite-demo__social-icon_facebook`)

## Чек-лист

<!-- Список для самопроверки. Поможет вам подготовить пулреквест для быстрого мёрджа. Часть пунктов может быть неактуальна для вашей задачи, просто отметьте их как сделанные -->

- [x] Текст оформлен [согласно руководству по стилю](https://github.com/doka-guide/content/blob/main/docs/styleguide.md)
- [x] Ссылки на внутренние материалы начинаются со слеша и заканчиваются слэшем либо якорем на заголовок (`/css/color/`, `/tools/json/`, `/tools/gulp/#kak-ponyat`)
- [x] Ссылки на картинки, видео и демки относительные (`images/example.png`, `demos/example/`, `../demos/example/`)
