### PR TITLE
Добавляет array.push() к списку методов массива в index

### DIFF
--- a/js/index.md
+++ b/js/index.md
@@ -96,6 +96,7 @@ groups:
       - includes
       - index-of
       - last-index-of
+      - array-push
       - array-length
       - array-from
       - array-of


### PR DESCRIPTION
## Описание

Добавляет ссылку на доку по array.push() в раздел Массивы.

## Чек-лист

- [x] Текст оформлен [согласно руководству по стилю](https://github.com/doka-guide/content/blob/main/docs/styleguide.md)
- [x] Ссылки на внутренние материалы начинаются со слеша и заканчиваются слэшем либо якорем на заголовок (`/css/color/`, `/tools/json/`, `/tools/gulp/#kak-ponyat`)
- [x] Ссылки на картинки, видео и демки относительные (`images/example.png`, `demos/example/`, `../demos/example/`)
