### PR TITLE
Упрощает диалог  в new.sh

### DIFF
--- a/new.sh
+++ b/new.sh
@@ -11,16 +11,25 @@ function jsonValue() {
   num=$2
   awk -F"[,:}]" '{for(i=1;i<=NF;i++){if($i~/'$KEY'\042/){print $(i+1)}}}' | tr -d '"' | sed -n ${num}p
 }
-LOGIN=$(echo $(curl -s https://api.github.com/search/users\?q\=$(echo $(git config --get user.email)) | jsonValue login))
 
-if [[ $LOGIN == "" ]]; then
-  read -r -p "$(echo "Введите ник на GitHub: ")" AUTHOR
-else
-  read -r -p "$(echo "Введите ник на GitHub (нажмите Enter, и будет использован $LOGIN): ")" AUTHORss
+if [[ -f ".env" ]]; then
+    source .env
 fi
 
 if [[ $AUTHOR == "" ]]; then
-  AUTHOR=$LOGIN
+  if [[ $LOGIN == "" ]]; then
+    LOGIN=$(echo $(curl -s https://api.github.com/search/users\?q\=$(echo $(git config --get user.email)) | jsonValue login))
+  fi
+
+  if [[ $LOGIN == "" ]]; then
+    read -r -p "$(echo "Введите ник на GitHub: ")" AUTHOR
+  else
+    read -r -p "$(echo "Введите ник на GitHub (нажмите Enter, и будет использован $LOGIN): ")" AUTHOR
+
+    if [[ $AUTHOR == "" ]]; then
+      AUTHOR=$LOGIN
+    fi
+  fi
 fi
 
 echo -e "\nДоступные разделы для публикации в Доке:"

--- a/new.sh
+++ b/new.sh
@@ -25,9 +25,13 @@ if [[ $AUTHOR == "" ]]; then
     read -r -p "$(echo "Введите ник на GitHub: ")" AUTHOR
   else
     read -r -p "$(echo "Введите ник на GitHub (нажмите Enter, и будет использован $LOGIN): ")" AUTHOR
+  fi
 
-    if [[ $AUTHOR == "" ]]; then
-      AUTHOR=$LOGIN
+  if [[ $AUTHOR != "" ]]; then
+    read -r -p "Сохранить ник '$AUTHOR' для последующих публикаций (y/n)?: " -n 1
+    echo
+    if [[ $REPLY =~ ^[Yy]$ ]] then
+        echo "AUTHOR=\"$AUTHOR\"" >> .env
     fi
   fi
 fi


### PR DESCRIPTION
## Описание

В текущей версии `new.sh` используется логика получения github-логина с использованием запроса:

```bash
LOGIN=$(echo $(curl -s https://api.github.com/search/users\?q\=$(echo $(git config --get user.email)) | jsonValue login))
```
Этот код имеет недостатки по двум причинам:
1. Запрос ничего не даст, в случае если в настройках github установлена опция `Keep my email addresses private` и в репозитории используется email вида `USER@users.noreply.github.com`. (Мне кажется, это довольно распространённая практика).
Вот что происходит в моём случае:
```bash
$ curl -s https://api.github.com/search/users\?q\=9317613+vitya-ne@users.noreply.github.com
{
  "total_count": 0,
  "incomplete_results": false,
  "items": [

  ]
}
```
2. Зачем вообще делать какой-то запрос на github, когда мы можем использовать `.env` файл для хранения переменных `LOGIN` или сразу `AUTHOR`.

### Предлагаю
Моё исправление даёт возможность:

1. Использовать опциональный файл `.env` для хранения переменных `LOGIN` или `AUTHOR`.
2. Если в файле установть переменную LOGIN:
```bash
LOGIN="имя автора в Доке"
```
Скрипт попросит подтвердить это значение или ввести другое.
3. Если в файле установть переменную AUTHOR:
```bash
AUTHOR="имя автора в Доке"
```
4. Скрипт считывает это имя и переходит к следующему вопросу:
```
Сохранить ник  для последующих публикаций (y/n)?:
```
Если пользователь подтвердил сохранение ника, значение переменной AUTHOR будет сохранено в файле `.env`.
При последующих запусках вводить ник не потребуется.

### Приемущеста

1. Не делаем ненужный запрос.
2. Задаём меньше вопросов.

## Чек-лист

- [x] Текст оформлен [согласно руководству по стилю](https://github.com/doka-guide/content/blob/main/docs/styleguide.md)
- [x] Ссылки на внутренние материалы начинаются со слеша и заканчиваются слэшем либо якорем на заголовок (`/css/color/`, `/tools/json/`, `/tools/gulp/#kak-ponyat`)
- [x] Ссылки на картинки, видео и демки относительные (`images/example.png`, `demos/example/`, `../demos/example/`)
