### PR TITLE
Дорабатывает код рецепта «Ленивая загрузка картинок»

### DIFF
--- a/recipes/lazy-load-with-preview/index.md
+++ b/recipes/lazy-load-with-preview/index.md
@@ -86,5 +86,8 @@ document.addEventListener('DOMContentLoaded', function() {
     progressiveImage.src = progressiveImage.getAttribute('data-src')
     progressiveImage.style.filter = 'none'
   }
+  lowResImage.onerror = function() {
+    progressiveImage.style.filter = 'none'
+  }
 })
 ```


### PR DESCRIPTION
## Описание

Если у изображения битый src или его не удалось загрузить по иным причинам, то мы получим заблюренный alt текст, чтобы этого избежать нужно добавить дополнительный хендлер onerror

## Чек-лист

<!-- Список для самопроверки. Поможет вам подготовить пулреквест для быстрого мёрджа. Часть пунктов может быть неактуальна для вашей задачи, просто отметьте их как сделанные -->

- [x] Текст оформлен [согласно руководству по стилю](https://github.com/doka-guide/content/blob/main/docs/styleguide.md)
- [x] Ссылки на внутренние материалы начинаются со слеша и заканчиваются слэшем либо якорем на заголовок (`/css/color/`, `/tools/json/`, `/tools/gulp/#kak-ponyat`)
- [x] Ссылки на картинки, видео и демки относительные (`images/example.png`, `demos/example/`, `../demos/example/`)
