### PR TITLE
Исправляет порядок применения функций filter, map в примере

### DIFF
--- a/js/deal-with-forms/index.md
+++ b/js/deal-with-forms/index.md
@@ -251,13 +251,13 @@ function serializeForm(formNode) {
   const { elements } = formNode
 
   const data = Array.from(elements)
+    .filter((item) => !!item.name)
     .map((element) => {
       const { name, type } = element
       const value = type === 'checkbox' ? element.checked : element.value
 
       return { name, value }
     })
-    .filter((item) => !!item.name)
 
   console.log(data)
 }


### PR DESCRIPTION
## Описание

Для статьи https://doka.guide/js/deal-with-forms/?utm_source=social в примере переместил использование функции filter перед функцией map.

Мне кажется, что так будет логичнее по 2м причинам.

1) В примерах до и после filter стоит перед map, а в этом примере он стоит ниже map и немного сбивает, начинаешь задумываться, а почему его вдруг переместили после map :)

2) С точки зрения работы логики, мы сначала через filter уберем пустой элемент для button (где name: ' '), а затем пройдемся map-ом. Иначе элемент button с пустым name будет учавствовать в обходе циклов 2 раза (один для map, а потом для filter). 

В примере ниже filter расположен выше map, и я думаю, что для текущего примера (по которому правка), просто случайно поменяли местами.

## Чек-лист

<!-- Список для самопроверки. Поможет вам подготовить пулреквест для быстрого мёрджа. Часть пунктов может быть неактуальна для вашей задачи, просто отметьте их как сделанные -->

- [x] Текст оформлен [согласно руководству по стилю](https://github.com/doka-guide/content/blob/main/docs/styleguide.md)
- [x] Ссылки на внутренние материалы начинаются со слеша и заканчиваются слэшем либо якорем на заголовок (`/css/color/`, `/tools/json/`, `/tools/gulp/#kak-ponyat`)
- [x] Ссылки на картинки, видео и демки относительные (`images/example.png`, `demos/example/`, `../demos/example/`)
