### PR TITLE
Исправляет ссылку nullish coalescing

### DIFF
--- a/js/if-else/practice/saharok.md
+++ b/js/if-else/practice/saharok.md
@@ -16,7 +16,7 @@ if (externalValue) {
 const value = externalValue || 0
 ```
 
-Неявное приведение `externalValue` к логическому типу также игнорирует _определённые ложные_ значения, возможно, вполне валидные: `''`, `NaN`, `0` , `-0`, `0n`, `false`. Чтобы их не терять, нужно вместо `||` использовать `??` — новый, уже [неплохо поддерживаемый](https://caniuse.com/?search=coalescing) логический оператор [nullish coalescing](https://learn.javascript.ru/nullish-coalescing-operator) из [ES2020](/js/language-versions/#es2020):
+Неявное приведение `externalValue` к логическому типу также игнорирует _определённые ложные_ значения, возможно, вполне валидные: `''`, `NaN`, `0` , `-0`, `0n`, `false`. Чтобы их не терять, нужно вместо `||` использовать `??` — новый, уже [неплохо поддерживаемый](https://caniuse.com/?search=coalescing) логический оператор [nullish coalescing](https://learn.javascript.ru/nullish-operators#operator-nulevogo-sliyaniya) из [ES2020](/js/language-versions/#es2020):
 
 ```js
 const value = externalValue ?? 42


### PR DESCRIPTION
## Описание

Исправляет ссылку на описание оператора nullish coalescing.

## Чек-лист

- [x] Текст оформлен [согласно руководству по стилю](https://github.com/doka-guide/content/blob/main/docs/styleguide.md)
- [x] Ссылки на внутренние материалы начинаются со слеша и заканчиваются слэшем либо якорем на заголовок (`/css/color/`, `/tools/json/`, `/tools/gulp/#kak-ponyat`)
- [x] Ссылки на картинки, видео и демки относительные (`images/example.png`, `demos/example/`, `../demos/example/`)
