### PR TITLE
Добавляет доку .closest() в индекс js

### DIFF
--- a/js/index.md
+++ b/js/index.md
@@ -208,6 +208,7 @@ groups:
       - getelementsbytagname
       - query-selector
       - query-selector-all
+      - element-closest
       - element-getattribute
       - element-focus
       - element-blur


### PR DESCRIPTION
## Описание

Добавляет доку .closest() в раздел Element

## Чек-лист

- [x] Текст оформлен [согласно руководству по стилю](https://github.com/doka-guide/content/blob/main/docs/styleguide.md)
- [x] Ссылки на внутренние материалы начинаются со слеша и заканчиваются слэшем либо якорем на заголовок (`/css/color/`, `/tools/json/`, `/tools/gulp/#kak-ponyat`)
- [x] Ссылки на картинки, видео и демки относительные (`images/example.png`, `demos/example/`, `../demos/example/`)
