### PR TITLE
Добавляет a11y и рецепты в скрипт обновления даты

### DIFF
--- a/.github/scripts/update-dates.js
+++ b/.github/scripts/update-dates.js
@@ -21,7 +21,7 @@ async function updateDates() {
 
       return [
         // учитываем только файлы, находящиеся в папках статей
-        ['html', 'css', 'js', 'tools'].includes(tag),
+        ['html', 'css', 'js', 'tools', 'a11y', 'recipes'].includes(tag),
         // не учитывем файлы индексов статей, например, 'css/index.md'
         pathSegments.length >= 3,
         // исключаем файлы index.11tydata.json


### PR DESCRIPTION
Чтобы дата наконец появилась в материалах раздела «Доступность» и «Рецепты».