### PR TITLE
Улучшения формы в статье Мгновенная валидация форм

### DIFF
--- a/people/kozlovtseva/index.md
+++ b/people/kozlovtseva/index.md
@@ -1,0 +1,6 @@
+---
+name: 'Алина Козловцева'
+url: https://github.com/kozlovtseva
+badges:
+  - first-contribution-small
+---

--- a/recipes/validation/demos/final-form/index.html
+++ b/recipes/validation/demos/final-form/index.html
@@ -203,7 +203,7 @@
     </style>
   </head>
   <body>
-    <form class="form" name="form" novalidate>
+    <form class="form" name="form" method="POST" novalidate>
       <div class="form__field-container">
         <label class="form__field">
           <span class="form__label">Имя:</span>
@@ -212,7 +212,7 @@
             id="input__name"
             class="form__type-input"
             placeholder="Иван"
-            pattern="^[a-zA-Zа-яА-ЯЁё\s\-]+$"
+            pattern="^[a-zA-Zа-яА-ЯЁё \-]+$"
             data-error-message="Разрешены символы латиницы, кириллицы, знаки дефиса и пробелы."
             aria-describedby="name-error"
             required
@@ -298,12 +298,18 @@
           event.preventDefault()
           if (hasInvalidInput()) {
             formError()
+            inputList.forEach((inputElement) => {
+              checkInputValidity(inputElement)
+            })
           }
         })
         inputList.forEach((inputElement) => {
-          inputElement.addEventListener('input', () => {
+          inputElement.addEventListener('blur', () => {
             checkInputValidity(inputElement)
             toggleButton()
+          })
+          inputElement.addEventListener('focus', () => {
+            toggleErrorSpan(inputElement)
           })
         })
       }

--- a/recipes/validation/demos/final-form/index.html
+++ b/recipes/validation/demos/final-form/index.html
@@ -119,6 +119,10 @@
         height: 24px;
         opacity: 0;
         padding: 0;
+        margin-block-end: 5px;
+        background-color: transparent;
+        -webkit-appearance: none;
+        appearance: none;
       }
 
       .form__type-checkbox + .form__type-checkbox-title::before {
@@ -271,7 +275,7 @@
           <input
             type="checkbox"
             id="input__checkbox"
-            class="form__type-input form__type-checkbox"
+            class="form__type-checkbox"
             checked
             aria-describedby="checkbox-error"
             required
@@ -287,6 +291,7 @@
     <script>
       const form = document.querySelector('.form')
       const inputList = Array.from(form.querySelectorAll('.form__type-input'))
+      const checkboxElement = form.querySelector('.form__type-checkbox')
       const buttonElement = form.querySelector('.button')
       const formErrorElement = form.querySelector('.form__empty-error')
 
@@ -300,18 +305,28 @@
             formError()
             inputList.forEach((inputElement) => {
               checkInputValidity(inputElement)
+              toggleInputError(inputElement)
             })
+            toggleInputError(checkboxElement)
           }
         })
         inputList.forEach((inputElement) => {
-          inputElement.addEventListener('blur', () => {
+          inputElement.addEventListener('input', () => {
             checkInputValidity(inputElement)
             toggleButton()
+          })
+          inputElement.addEventListener('blur', () => {
+            toggleInputError(inputElement)
           })
           inputElement.addEventListener('focus', () => {
             toggleErrorSpan(inputElement)
           })
         })
+        checkboxElement.addEventListener('change', () => {
+          toggleInputError(checkboxElement)
+          toggleButton()
+        })
+
       }
 
       function checkInputValidity(inputElement) {
@@ -319,12 +334,6 @@
           inputElement.setCustomValidity(inputElement.dataset.errorMessage)
         } else {
           inputElement.setCustomValidity(checkLengthMismatch(inputElement))
-        }
-
-        if (!inputElement.validity.valid) {
-          toggleErrorSpan(inputElement, inputElement.validationMessage)
-        } else {
-          toggleErrorSpan(inputElement)
         }
       }
 
@@ -340,9 +349,17 @@
       }
 
       function hasInvalidInput() {
-        return inputList.some((inputElement) => {
-          return !inputElement.validity.valid
-        })
+        return (
+          inputList.some(inputElement => !inputElement.validity.valid) || !checkboxElement.validity.valid
+        )
+      }
+
+      function toggleInputError(inputElement) {
+        if (!inputElement.validity.valid) {
+          toggleErrorSpan(inputElement, inputElement.validationMessage)
+        } else {
+          toggleErrorSpan(inputElement)
+        }
       }
 
       function toggleErrorSpan(inputElement, errorMessage) {

--- a/recipes/validation/index.md
+++ b/recipes/validation/index.md
@@ -123,7 +123,7 @@ tags:
       <input
         type="checkbox"
         id="input__checkbox"
-        class="form__type-input form__type-checkbox"
+        class="form__type-checkbox"
         checked
         aria-describedby="checkbox-error"
         required
@@ -155,6 +155,7 @@ tags:
 ``` js
 const form = document.querySelector('.form')
 const inputList = Array.from(form.querySelectorAll('.form__type-input'))
+const checkboxElement = form.querySelector('.form__type-checkbox')
 const buttonElement = form.querySelector('.button')
 const formErrorElement = form.querySelector('.form__empty-error')
 
@@ -168,16 +169,25 @@ function startValidation() {
       formError()
       inputList.forEach((inputElement) => {
         checkInputValidity(inputElement)
+        toggleInputError(inputElement)
       })
+      toggleInputError(checkboxElement)
     }
   })
   inputList.forEach((inputElement) => {
-    inputElement.addEventListener('blur', () => {
+    inputElement.addEventListener('input', () => {
       checkInputValidity(inputElement)
       toggleButton()
     })
+    inputElement.addEventListener('blur', () => {
+      toggleInputError(inputElement)
+    })
     inputElement.addEventListener('focus', () => {
       toggleErrorSpan(inputElement)
+    })
+    checkboxElement.addEventListener('change', () => {
+      toggleInputError(checkboxElement)
+      toggleButton()
     })
   })
 }
@@ -187,11 +197,6 @@ function checkInputValidity(inputElement) {
     inputElement.setCustomValidity(inputElement.dataset.errorMessage)
   } else {
     inputElement.setCustomValidity(checkLengthMismatch(inputElement))
-  }
-  if (!inputElement.validity.valid) {
-    toggleErrorSpan(inputElement, inputElement.validationMessage)
-  } else {
-    toggleErrorSpan(inputElement)
   }
 }
 
@@ -207,9 +212,9 @@ function checkLengthMismatch(inputElement) {
 }
 
 function hasInvalidInput() {
-  return inputList.some((inputElement) => {
-    return !inputElement.validity.valid
-  })
+  return (
+    inputList.some(inputElement => !inputElement.validity.valid) || !checkboxElement.validity.valid
+  )
 }
 
 function toggleErrorSpan(inputElement, errorMessage){
@@ -328,13 +333,15 @@ CSS-стили, которые будут использоваться при в
 ```js
 const form = document.querySelector('.form')
 const inputList = Array.from(form.querySelectorAll('.form__type-input'))
+const checkboxElement = form.querySelector('.form__type-checkbox')
 const buttonElement = form.querySelector('.button')
 const formErrorElement = form.querySelector('.form__empty-error')
 ```
 
 Функция `startValidation()` инициирует процесс валидации. Она добавляет обработчик событий для всей формы на событие [`submit`](/js/event-submit/), где используется [`event.preventDefault()`](/js/event-prevent-default/) для предотвращения стандартного поведения формы при отправке. Для дополнительной информации читайте «[Работа с формами](/js/deal-with-forms/)».
 
-На каждый элемент формы назначаются обработчики события `blur` и `focus`. При потере фокуса активируются функции `checkInputValidity()` и `toggleButton()`, а при установке фокуса сбрасывается сообщение об ошибке с помощью `toggleErrorSpan()`. Эти функции мы напишем далее.
+На каждое поле ввода назначаются обработчики событий `input`, `blur` и `focus`. При любых изменениях в полях ввода активируются функции `checkInputValidity()` и `toggleButton()`. При потере фокуса активируется функция `toggleInputError()`, а при установке фокуса сбрасывается сообщение об ошибке с помощью `toggleErrorSpan()`.
+Для чекбокса добавим отдельный обработчик `change`, при срабатывании такого события вызовутся функции `toggleInputError()` и `toggleButton()`. Все эти функции мы напишем далее.
 
 ```js
 function startValidation() {
@@ -344,18 +351,28 @@ function startValidation() {
       formError()
       inputList.forEach((inputElement) => {
         checkInputValidity(inputElement)
+        toggleInputError(inputElement)
       })
+      toggleInputError(checkboxElement)
     }
   })
 
   inputList.forEach((inputElement) => {
-    inputElement.addEventListener('blur', () => {
+    inputElement.addEventListener('input', () => {
       checkInputValidity(inputElement)
       toggleButton()
+    })
+    inputElement.addEventListener('blur', () => {
+      toggleInputError(inputElement)
     })
     inputElement.addEventListener('focus', () => {
       toggleErrorSpan(inputElement)
     })
+  })
+
+  checkboxElement.addEventListener('change', () => {
+    toggleInputError(checkboxElement)
+    toggleButton()
   })
 }
 ```
@@ -386,7 +403,7 @@ function startValidation() {
 
 Сначала проверяется задан ли для поля ввода определённый паттерн и установлена ли минимальная длина. Если паттерн задан и не совпадает с введёнными данными, то с помощью функции [`setCustomValidity`](https://developer.mozilla.org/en-US/docs/Web/API/HTMLObjectElement/setCustomValidity) передаётся кастомное сообщение об ошибке, хранящееся в атрибуте `data-error-message`. В случае соответствия введённых данных паттерну, с помощью функции `checkLengthMismatch()` также проверяется длина введённых данных, очищенная от пробелов. Если сообщение больше установленного количества символов и не пустое, то сообщение об ошибке не передаётся, в ином случае — пользователь получает сообщение с минимально необходимым количеством символов.
 
-Затем проводится стандартная проверка: если свойство `input.validity.valid` равно `false`, выводится сообщение об ошибке, а если `true` — ошибка убирается.
+В функции `toggleInputError()` реализована стандартная проверка: если свойство `input.validity.valid` равно `false`, выводится сообщение об ошибке, а если `true` — ошибка убирается.
 
 ```js
 function checkInputValidity(inputElement) {
@@ -394,11 +411,6 @@ function checkInputValidity(inputElement) {
     inputElement.setCustomValidity(inputElement.dataset.errorMessage)
   } else {
     inputElement.setCustomValidity(checkLengthMismatch(inputElement))
-  }
-  if (!inputElement.validity.valid) {
-    toggleErrorSpan(inputElement, inputElement.validationMessage)
-  } else {
-    toggleErrorSpan(inputElement)
   }
 }
 
@@ -412,16 +424,25 @@ function checkLengthMismatch(inputElement) {
   }
   return ''
 }
+
+function toggleInputError(inputElement) {
+  if (!inputElement.validity.valid) {
+    toggleErrorSpan(inputElement, inputElement.validationMessage)
+  } else {
+    toggleErrorSpan(inputElement)
+  }
+}
 ```
 
-Функция `toggleButton()` устроена просто: она блокирует кнопку, когда находит невалидные поля, и вновь активирует её, если все поля заполнены корректно. Функция `hasInvalidInput()` проверяет поля ввода на наличие ошибок и возвращает `true` или `false`, основываясь на том, обнаружены ли невалидные данные.
+Функция `toggleButton()` устроена просто: она блокирует кнопку, когда находит невалидные поля, и вновь активирует её, если все поля заполнены корректно. Функция `hasInvalidInput()` проверяет поля ввода и чекбокс на наличие ошибок и возвращает `true` или `false`, основываясь на том, обнаружены ли невалидные данные.
 
 Блокировка кнопки отправки формы — рискованный приём. Важно учитывать различные варианты поведения пользователя. Чтобы избежать ситуаций, когда пользователь не понимает причину блокировки кнопки, мы принимаем следующие меры:
 
 - Применяем класс `button-inactive`, который изменяет цвет кнопки на менее яркий, подсказывая пользователю, что нажатие невозможно.
 - Добавляем через этот класс свойства [`cursor: not-allowed;`](/css/cursor/), которое меняет форму курсора на символ запрета.
 - При клике по кнопке отправки формы или при нажатии на неё с клавиатуры показываем ошибку, которая объясняет причину блокировки. Реализуем это с помощью JavaScript.
-- В случае ввода невалидных данных в одно из полей, пользователь моментально получает обратную связь о допущенной ошибке.
+- В случае ввода невалидных данных в одно из полей, пользователь получает обратную связь о допущенной ошибке после потери фокуса на поле или после того, как снят маркер с обязательного чекбокса.
+- Как только пользователь ввёл валидные данные, кнопка становится активной.
 - Чтобы заблокированная кнопка была заметна пользователям, перемещающимся по сайту с помощью клавиши <kbd>Tab</kbd>, мы добавляем к кнопке атрибут [`aria-disabled`](/a11y/aria-disabled/).
 
 Так же напоминаем, что при блокировке кнопки отправки формы важно удостовериться, что требования к заполнению формы разумны и могут быть выполнены всеми пользователями. Следует избегать установления _чрезмерно строгих условий_ для данных, вводимых пользователем. К примеру, пользователь может столкнуться с тем, что его имя слишком длинное для установленного в форме ограничения в 10 символов, что сделает невозможным отправку формы и ограничит доступ к вашему продукту.
@@ -439,9 +460,9 @@ function toggleButton() {
 }
 
 function hasInvalidInput() {
-  return inputList.some((inputElement) => {
-    return !inputElement.validity.valid
-  })
+  return (
+    inputList.some(inputElement => !inputElement.validity.valid) || !checkboxElement.validity.valid
+  )
 }
 
 function formError() {
@@ -492,7 +513,6 @@ function toggleErrorSpan(inputElement, errorMessage){
 const formErrorElement = form.querySelector('.form__empty-error')
 
 function startValidation() {
-  toggleButton()
   form.addEventListener('submit', (event) => {
     event.preventDefault()
     // Показываем ошибку
@@ -500,17 +520,26 @@ function startValidation() {
       formError()
       inputList.forEach((inputElement) => {
         checkInputValidity(inputElement)
+        toggleInputError(inputElement)
       })
+      toggleInputError(checkboxElement)
     }
   })
   inputList.forEach((inputElement) => {
-    inputElement.addEventListener('blur', () => {
+    inputElement.addEventListener('input', () => {
       checkInputValidity(inputElement)
       toggleButton()
+    })
+    inputElement.addEventListener('blur', () => {
+      toggleInputError(inputElement)
     })
     inputElement.addEventListener('focus', () => {
       toggleErrorSpan(inputElement)
     })
+  })
+  checkboxElement.addEventListener('change', () => {
+    toggleInputError(checkboxElement)
+    toggleButton()
   })
 }
 
@@ -551,18 +580,27 @@ function startValidation() {
       formError()
       inputList.forEach((inputElement) => {
         checkInputValidity(inputElement)
+        toggleInputError(inputElement)
       })
+      toggleInputError(checkboxElement)
     }
   })
 
   inputList.forEach((inputElement) => {
-    inputElement.addEventListener('blur', () => {
+    inputElement.addEventListener('input', () => {
       checkInputValidity(inputElement)
       toggleButton()
+    })
+    inputElement.addEventListener('blur', () => {
+      toggleInputError(inputElement)
     })
     inputElement.addEventListener('focus', () => {
       toggleErrorSpan(inputElement)
     })
+  })
+  checkboxElement.addEventListener('change', () => {
+    toggleInputError(checkboxElement)
+    toggleButton()
   })
 }
 ```

--- a/recipes/validation/index.md
+++ b/recipes/validation/index.md
@@ -6,6 +6,7 @@ authors:
 contributors:
   - skorobaeus
   - tatianafokina
+  - kozlovtseva
 related:
   - js/forms
   - html/form
@@ -28,6 +29,7 @@ tags:
 <form
   class="form"
   name="form"
+  method="POST"
   novalidate
 >
   <div class="form__field-container">
@@ -38,7 +40,7 @@ tags:
         id="input__name"
         class="form__type-input"
         placeholder="Иван"
-        pattern="^[a-zA-Zа-яА-ЯЁё\s\-]+$"
+        pattern="^[a-zA-Zа-яА-ЯЁё \-]+$"
         data-error-message="Разрешены символы латиницы,
         кириллицы, знаки дефиса и пробелы."
         aria-describedby="name-error"
@@ -164,12 +166,18 @@ function startValidation() {
     event.preventDefault()
     if (hasInvalidInput()) {
       formError()
+      inputList.forEach((inputElement) => {
+        checkInputValidity(inputElement)
+      })
     }
   })
   inputList.forEach((inputElement) => {
-    inputElement.addEventListener('input', () => {
+    inputElement.addEventListener('blur', () => {
       checkInputValidity(inputElement)
       toggleButton()
+    })
+    inputElement.addEventListener('focus', () => {
+      toggleErrorSpan(inputElement)
     })
   })
 }
@@ -297,7 +305,7 @@ CSS-стили, которые будут использоваться при в
     id="input__name"
     class="form__type-input"
     placeholder="Иван"
-    pattern="^[a-zA-Zа-яА-ЯЁё\s\-]+$"
+    pattern="^[a-zA-Zа-яА-ЯЁё \-]+$"
     data-error-message="Разрешены символы латиницы,
     кириллицы, знаки дефиса и пробелы."
     aria-describedby="name-error"
@@ -326,7 +334,7 @@ const formErrorElement = form.querySelector('.form__empty-error')
 
 Функция `startValidation()` инициирует процесс валидации. Она добавляет обработчик событий для всей формы на событие [`submit`](/js/event-submit/), где используется [`event.preventDefault()`](/js/event-prevent-default/) для предотвращения стандартного поведения формы при отправке. Для дополнительной информации читайте «[Работа с формами](/js/deal-with-forms/)».
 
-На каждый элемент формы назначаются обработчики события [`input`](/js/event-input/). Они активируют функции `checkInputValidity()` и `toggleButton()` при любых изменениях в полях ввода. Их мы напишем далее.
+На каждый элемент формы назначаются обработчики события `blur` и `focus`. При потере фокуса активируются функции `checkInputValidity()` и `toggleButton()`, а при установке фокуса сбрасывается сообщение об ошибке с помощью `toggleErrorSpan()`. Эти функции мы напишем далее.
 
 ```js
 function startValidation() {
@@ -334,13 +342,19 @@ function startValidation() {
     event.preventDefault()
     if (hasInvalidInput()) {
       formError()
+      inputList.forEach((inputElement) => {
+        checkInputValidity(inputElement)
+      })
     }
   })
 
   inputList.forEach((inputElement) => {
-    inputElement.addEventListener('input', () => {
+    inputElement.addEventListener('blur', () => {
       checkInputValidity(inputElement)
       toggleButton()
+    })
+    inputElement.addEventListener('focus', () => {
+      toggleErrorSpan(inputElement)
     })
   })
 }
@@ -484,12 +498,18 @@ function startValidation() {
     // Показываем ошибку
     if (hasInvalidInput()) {
       formError()
+      inputList.forEach((inputElement) => {
+        checkInputValidity(inputElement)
+      })
     }
   })
   inputList.forEach((inputElement) => {
-    inputElement.addEventListener('input', () => {
+    inputElement.addEventListener('blur', () => {
       checkInputValidity(inputElement)
       toggleButton()
+    })
+    inputElement.addEventListener('focus', () => {
+      toggleErrorSpan(inputElement)
     })
   })
 }
@@ -529,13 +549,19 @@ function startValidation() {
     event.preventDefault()
     if (hasInvalidInput()) {
       formError()
+      inputList.forEach((inputElement) => {
+        checkInputValidity(inputElement)
+      })
     }
   })
 
   inputList.forEach((inputElement) => {
-    inputElement.addEventListener('input', () => {
+    inputElement.addEventListener('blur', () => {
       checkInputValidity(inputElement)
       toggleButton()
+    })
+    inputElement.addEventListener('focus', () => {
+      toggleErrorSpan(inputElement)
     })
   })
 }


### PR DESCRIPTION
## Описание

Улучшения формы в статье Мгновенная валидация форм:
- валидация поля при вводе, отображение ошибок при анфокусе и по событию submit, сброс валидации на поле с фокусом
- чекбокс вынесен отдельно от общего списка инпутов, тк событие blur на нем отрабатывает в момент повторного клика, а мы этого не хотим. Для чекбокса отдельно добавлено событие 'change' ('input', 'blur', 'focus' ему не нужны)
- исправлен символ пробела в регулярке
- добавлен метод пост
- отредактировано описание функций в соответствии с правками

номер ишью - #5273 

## Чек-лист

<!-- Список для самопроверки. Поможет вам подготовить пулреквест для быстрого мёрджа. Часть пунктов может быть неактуальна для вашей задачи, просто отметьте их как сделанные -->

- [✓] Текст оформлен [согласно руководству по стилю](https://github.com/doka-guide/content/blob/main/docs/styleguide.md)
- [✓] Ссылки на внутренние материалы начинаются со слеша и заканчиваются слэшем либо якорем на заголовок (`/css/color/`, `/tools/json/`, `/tools/gulp/#kak-ponyat`)
- [✓] Ссылки на картинки, видео и демки относительные (`images/example.png`, `demos/example/`, `../demos/example/`)
