### PR TITLE
Чинит демку

### DIFF
--- a/css/transform/demos/playground/index.html
+++ b/css/transform/demos/playground/index.html
@@ -182,7 +182,7 @@
     }
     gui.add(params, 'reset')
 
-    guiTranslate.add(params, 'translateX', -100, 100, 1).onChange(setter('--translateX', 'px')).listen()
+    guiTranslate.add(params, 'translateX', -100, 100, 1).onChange(setter('--translateX', 'px'))
     guiTranslate.add(params, 'translateY', -100, 100, 1).onChange(setter('--translateY', 'px'))
     guiTranslate.add(params, 'translateZ', -100, 100, 1).onChange(setter('--translateZ', 'px'))
     guiRotate.add(params, 'rotateX', -180, 180, 1).onChange(setter('--rotateX', 'deg'))


### PR DESCRIPTION
## Описание

<!-- Кратко опишите изменение -->

[Демка из статьи про `transform`](https://doka.guide/css/transform/demos/playground/)
Попробуйте с клавиатуры ввести значение translateX. Не получится, только ползунком. Хотя остальные функции можно и так и так изменять.

Там используется библиотека dat.GUI. Я попробовал убрать метод `.listen()` — всё работает как надо.

Аналогичная проблема описана [здесь](https://github.com/dataarts/dat.gui/issues/206) и [здесь](https://github.com/NVlabs/WebFPSci/issues/3)

## Чек-лист

<!-- Список для самопроверки. Поможет вам подготовить пулреквест для быстрого мёрджа. Часть пунктов может быть неактуальна для вашей задачи, просто отметьте их как сделанные -->

- [ ] Текст оформлен [согласно руководству по стилю](https://github.com/doka-guide/content/blob/main/docs/styleguide.md)
- [ ] Ссылки на внутренние материалы начинаются со слеша и заканчиваются слэшем либо якорем на заголовок (`/css/color/`, `/tools/json/`, `/tools/gulp/#kak-ponyat`)
- [ ] Ссылки на картинки, видео и демки относительные (`images/example.png`, `demos/example/`, `../demos/example/`)
