### PR TITLE
Исправляет ошибку вывода при вызове генератора

### DIFF
--- a/js/generators/index.md
+++ b/js/generators/index.md
@@ -59,7 +59,9 @@ generator.next()
 generator.next()
 // { value: 'js', done: false }
 generator.next()
-// { value: 'rust', done: true }
+// { value: 'rust', done: false }
+generator.next()
+// { value: undefined, done: true }
 ```
 
 Так как генератор это ещё и **итерируемый объект**, то можно использовать его в цикле [`for..of`](/js/for-of/).


### PR DESCRIPTION
## Описание
При вызове `.next()` у генератора, `done: true` вернется после того, как все `yield` закончатся

## Чек-лист
- [x] Текст оформлен [согласно руководству по стилю](https://github.com/doka-guide/content/blob/main/docs/styleguide.md)
- [x] Ссылки на внутренние материалы начинаются со слеша и заканчиваются слэшем либо якорем на заголовок (`/css/color/`, `/tools/json/`, `/tools/gulp/#kak-ponyat`)
- [x] Ссылки на картинки, видео и демки относительные (`images/example.png`, `demos/example/`, `../demos/example/`)
