### PR TITLE
Обновляет индекс раздела "Веб-платформа"

### DIFF
--- a/tools/index.md
+++ b/tools/index.md
@@ -65,6 +65,7 @@ groups:
       - static-analysis
       - nodejs
       - nodejs-tooling
+      - deno
       - rollup
       - gulp
 


### PR DESCRIPTION
## Описание

Добавляет статью про [Deno](https://doka.guide/tools/deno/) в секцию `Сборка проекта`, чтобы Node.js чувствовал конкуренцию даже тут.
Возможно Deno и Node,js достойны отдельного раздела, но пока его нет, помоему лучше, чтобы они  были рядом.

## Чек-лист

- [x] Текст оформлен [согласно руководству по стилю](https://github.com/doka-guide/content/blob/main/docs/styleguide.md)
- [x] Ссылки на внутренние материалы начинаются со слеша и заканчиваются слэшем либо якорем на заголовок (`/css/color/`, `/tools/json/`, `/tools/gulp/#kak-ponyat`)
- [x] Ссылки на картинки, видео и демки относительные (`images/example.png`, `demos/example/`, `../demos/example/`)
