### PR TITLE
Добавлены допустимые теги внутри <head>

### DIFF
--- a/html/head/index.md
+++ b/html/head/index.md
@@ -42,7 +42,7 @@ tags:
 
 ## Как пишется
 
-Кроме `<title>`, внутри контейнера `<head>` можно разместить и другие элементы: [`<base>`](/html/base/), [`<link>`](/html/link/), [`<meta>`](/html/meta/), [`<script>`](/html/script/), [`<style>`](/html/style/). Вот пример того, как можно поставить фавиконку — маленькую иконку в углу вкладки браузера.
+Кроме `<title>`, внутри контейнера `<head>` можно разместить и другие элементы: [`<base>`](/html/base/), [`<link>`](/html/link/), [`<meta>`](/html/meta/), [`<script>`](/html/script/), [`<style>`](/html/style/), [`<template>`](/html/template/), [`<noscript>`](/html/noscript/). Вот пример того, как можно поставить фавиконку — маленькую иконку в углу вкладки браузера.
 
 ```html
 <head>


### PR DESCRIPTION
## Описание

Предлагаю добавить `<template>`  и `<noscript>` в список тегов, которые можно использовать внутри `<head>`. Тогда в доке будет полный список допустимых тегов.

## Чек-лист

<!-- Список для самопроверки. Поможет вам подготовить пулреквест для быстрого мёрджа. Часть пунктов может быть неактуальна для вашей задачи, просто отметьте их как сделанные -->

- [x] Текст оформлен [согласно руководству по стилю](https://github.com/doka-guide/content/blob/main/docs/styleguide.md)
- [x] Ссылки на внутренние материалы начинаются со слеша и заканчиваются слэшем либо якорем на заголовок (`/css/color/`, `/tools/json/`, `/tools/gulp/#kak-ponyat`)
- [x] Ссылки на картинки, видео и демки относительные (`images/example.png`, `demos/example/`, `../demos/example/`)
