### PR TITLE
Устанавливает `aria-hidden="true"` для снежинок

### DIFF
--- a/recipes/snow/demos/result-no-toggler/index.html
+++ b/recipes/snow/demos/result-no-toggler/index.html
@@ -57,7 +57,7 @@
   </style>
 </head>
 <body>
-  <div class="snow">
+  <div class="snow" aria-hidden="true">
     <div class="snow__flake">﹡</div>
     <div class="snow__flake">﹡</div>
     <div class="snow__flake">﹡</div>

--- a/recipes/snow/demos/result/index.html
+++ b/recipes/snow/demos/result/index.html
@@ -114,7 +114,7 @@
   </style>
 </head>
 <body>
-  <div class="snow">
+  <div class="snow" aria-hidden="true">
     <div class="snow__flake">﹡</div>
     <div class="snow__flake">﹡</div>
     <div class="snow__flake">﹡</div>

--- a/recipes/snow/index.md
+++ b/recipes/snow/index.md
@@ -31,7 +31,7 @@ tags:
 Поместите HTML-разметку в конец страницы:
 
 ```html
-<div class="snow">
+<div class="snow" aria-hidden="true">
   <div class="snow__flake">﹡</div>
   <div class="snow__flake">﹡</div>
   <div class="snow__flake">﹡</div>
@@ -215,10 +215,10 @@ document.addEventListener('DOMContentLoaded', () => {
 
 ### Разметка
 
-Создадим разметку для снежинок. Понадобится родительский контейнер с классом `snow`. Внутри будут блоки с классом `snow__flake` и символом `﹡` в контенте.
+Создадим разметку для снежинок. Понадобится родительский контейнер с классом `snow`. Внутри будут блоки с классом `snow__flake` и символом `﹡` в контенте. Чтобы [скринридеры](/a11y/screenreaders/) не читали звёздочки, добавим атрибут [`aria-hidden`](/a11y/aria-hidden/) со значением `true`.
 
 ```html
-<div class="snow">
+<div class="snow" aria-hidden="true">
   <div class="snow__flake">﹡</div>
   <div class="snow__flake">﹡</div>
   <div class="snow__flake">﹡</div>
@@ -389,7 +389,7 @@ snowflakes.forEach(snowflake => {
 ### Финальный код
 
 ```html
-<div class="snow">
+<div class="snow" aria-hidden="true">
   <div class="snow__flake">﹡</div>
   <div class="snow__flake">﹡</div>
   <div class="snow__flake">﹡</div>
@@ -562,7 +562,7 @@ document.addEventListener('DOMContentLoaded', () => {
 ### Финальный код с переключателями
 
 ```html
-<div class="snow">
+<div class="snow" aria-hidden="true">
   <div class="snow__flake">﹡</div>
   <div class="snow__flake">﹡</div>
   <div class="snow__flake">﹡</div>


### PR DESCRIPTION
## Описание

Стоит добавить `aria-hidden="true"` в код рецепта, так как без него пользователь скринридера будет слушать все 90 звёздочек 😭

## Чек-лист

- [x] Текст оформлен [согласно руководству по стилю](https://github.com/doka-guide/content/blob/main/docs/styleguide.md)
- [x] Ссылки на внутренние материалы начинаются со слеша и заканчиваются слэшем либо якорем на заголовок (`/css/color/`, `/tools/json/`, `/tools/gulp/#kak-ponyat`)
- [x] Ссылки на картинки, видео и демки относительные (`images/example.png`, `demos/example/`, `../demos/example/`)
