### PR TITLE
Убирает пустые строки в списках из CHANGELOG.md

### DIFF
--- a/.github/scripts/update-changelog.js
+++ b/.github/scripts/update-changelog.js
@@ -84,7 +84,7 @@ if (addedContentList.length > 0) {
       changelog.splice(headerPosition, 0, ...[header, "", ""]);
       changelog.splice(headerPosition + 2, 0, ...addedContentList);
     }
-    fs.writeFileSync(changelogFileName, changelog.filter(line => line.trim() !== "" || line.startsWith("##")).join("\n"));
+    fs.writeFileSync(changelogFileName, changelog.filter(line => line.trim() !== "").join("\n"));
     console.log("Новые материалы добавлены в CHANGELOG.md");
   }
 } else {
@@ -116,7 +116,7 @@ if (updatedContentList.length > 0) {
       changelog.splice(headerPosition, 0, ...[header, "", ""]);
       changelog.splice(headerPosition + 2, 0, ...updatedContentList);
     }
-    fs.writeFileSync(changelogFileName, changelog.filter(line => line.trim() !== "" || line.startsWith("##")).join("\n"));
+    fs.writeFileSync(changelogFileName, changelog.filter(line => line.trim() !== "").join("\n"));
     console.log("Бывшие плейсхолдеры добавлены в CHANGELOG.md");
   }
 } else {

--- a/.github/scripts/update-changelog.js
+++ b/.github/scripts/update-changelog.js
@@ -84,7 +84,7 @@ if (addedContentList.length > 0) {
       changelog.splice(headerPosition, 0, ...[header, "", ""]);
       changelog.splice(headerPosition + 2, 0, ...addedContentList);
     }
-    fs.writeFileSync(changelogFileName, changelog.join("\n"));
+    fs.writeFileSync(changelogFileName, changelog.filter(line => line.trim() !== "" || line.startsWith("##")).join("\n"));
     console.log("Новые материалы добавлены в CHANGELOG.md");
   }
 } else {
@@ -116,7 +116,7 @@ if (updatedContentList.length > 0) {
       changelog.splice(headerPosition, 0, ...[header, "", ""]);
       changelog.splice(headerPosition + 2, 0, ...updatedContentList);
     }
-    fs.writeFileSync(changelogFileName, changelog.join("\n"));
+    fs.writeFileSync(changelogFileName, changelog.filter(line => line.trim() !== "" || line.startsWith("##")).join("\n"));
     console.log("Бывшие плейсхолдеры добавлены в CHANGELOG.md");
   }
 } else {


### PR DESCRIPTION
## Описание

Сейчас при записи изменений в файлик с ченджлогом между пунктами списков добавляются пробелы. Попыталась исправить эту мелочь.

![image](https://github.com/user-attachments/assets/4c98de0e-4415-479e-acdc-f155162e0979)