### PR TITLE
Убирает предупреждение о неработающем scrollbar-gutter в Safari

### DIFF
--- a/css/scrollbar-gutter/index.md
+++ b/css/scrollbar-gutter/index.md
@@ -52,7 +52,3 @@ body {
 ```
 
 <iframe title="Убираем сдвиги контента" src="demos/good" height="400"></iframe>
-
-## Поддержка
-
-`scrollbar-gutter` поддерживается всеми современными браузерами, кроме Safari. Подробнее можно посмотреть на [Can I Use](https://caniuse.com/mdn-css_properties_scrollbar-gutter).

--- a/css/scrollbar-gutter/index.md
+++ b/css/scrollbar-gutter/index.md
@@ -4,9 +4,9 @@ description: "Добавляем отступ под скроллбар, что�
 baseline:
   - group: scrolling
     features:
-     - css.properties.scrollbar-gutter
-     - css.properties.scrollbar-gutter.auto
-     - css.properties.scrollbar-gutter.stable
+      - css.properties.scrollbar-gutter
+      - css.properties.scrollbar-gutter.auto
+      - css.properties.scrollbar-gutter.stable
 authors:
   - xpleesid
 keywords:

--- a/css/scrollbar-gutter/index.md
+++ b/css/scrollbar-gutter/index.md
@@ -1,6 +1,12 @@
 ---
 title: "`scrollbar-gutter`"
 description: "Добавляем отступ под скроллбар, чтобы его появление или скрытие не вызывало сдвиги контента."
+baseline:
+  - group: scrolling
+    features:
+     - css.properties.scrollbar-gutter
+     - css.properties.scrollbar-gutter.auto
+     - css.properties.scrollbar-gutter.stable
 authors:
   - xpleesid
 keywords:


### PR DESCRIPTION
## Описание

Заметил, что в [статье про scrollbar-gutter](https://doka.guide/css/scrollbar-gutter/) говорится о том, что это свойство недоступно в сафари.

Но в сафари 18.2 [добавили поддержку](https://caniuse.com/mdn-css_properties_scrollbar-gutter), поэтому этот абзац больше не актуален.

## Чек-лист

<!-- Список для самопроверки. Поможет вам подготовить пулреквест для быстрого мёрджа. Часть пунктов может быть неактуальна для вашей задачи, просто отметьте их как сделанные -->

- [x] Текст оформлен [согласно руководству по стилю](https://github.com/doka-guide/content/blob/main/docs/styleguide.md)
- [x] Ссылки на внутренние материалы начинаются со слеша и заканчиваются слэшем либо якорем на заголовок (`/css/color/`, `/tools/json/`, `/tools/gulp/#kak-ponyat`)
- [x] Ссылки на картинки, видео и демки относительные (`images/example.png`, `demos/example/`, `../demos/example/`)
