### PR TITLE
Исправляет ошибку в статье 'Поведенческие паттерны проектирования'

### DIFF
--- a/tools/design-patterns-behaviorial/index.md
+++ b/tools/design-patterns-behaviorial/index.md
@@ -87,11 +87,11 @@ const automobileRoute: RouteStrategy = {
 ```ts
 class Context {
   // При создании укажем стратегию, которую будем использовать:
-  constructor(private routeFinder: Strategy) {}
+  constructor(private routeFinder: RouteStrategy) {}
 
   // Иногда полезно менять стратегию во время работы,
   // сделаем метод для этого
-  public use(routeFinder: Strategy) {
+  public use(routeFinder: RouteStrategy) {
     this.routeFinder = routeFinder
   }
 


### PR DESCRIPTION
## Описание
Исправляет название интерфейса для поля `routeFinder` класса `Context` на `RouteStrategy`.