### PR TITLE
Добавляет конфигурацию baseline для css и html фич ('широко поддерживаемые' за 2023-2024)

### DIFF
--- a/css/appearance/index.md
+++ b/css/appearance/index.md
@@ -1,6 +1,23 @@
 ---
 title: "`appearance`"
 description: "Сбрасывает стандартный внешний вид элементов."
+baseline:
+  - group: appearance
+    features:
+      - css.properties.appearance
+      - css.properties.appearance.auto
+      - css.properties.appearance.button
+      - css.properties.appearance.checkbox
+      - css.properties.appearance.listbox
+      - css.properties.appearance.menulist
+      - css.properties.appearance.menulist-button
+      - css.properties.appearance.meter
+      - css.properties.appearance.none
+      - css.properties.appearance.progress-bar
+      - css.properties.appearance.radio
+      - css.properties.appearance.searchfield
+      - css.properties.appearance.textarea
+      - css.properties.appearance.textfield
 authors:
   - ezhkov
 editors:
@@ -21,8 +38,6 @@ tags:
 Некоторые элементы форм имеют уникальный внешний вид в каждой операционной системе. Например, выпадающий список в macOS внешне выглядит совсем не так, как такой же выпадающий список в Windows.
 
 Свойство `appearance` позволяет задавать внешний вид одних элементов другим элементам. При этом браузер будет отрисовывать их с учётом текущей операционной системы пользователя и темы оформления.
-
-В настоящее время используется в основном `appearance: none` для сброса системных стилей, остальные значения не работают практически ни в одном браузере.
 
 ## Как понять
 

--- a/css/aspect-ratio/index.md
+++ b/css/aspect-ratio/index.md
@@ -1,6 +1,13 @@
 ---
 title: "`aspect-ratio`"
 description: "Помогает задать соотношение сторон для элемента."
+baseline:
+  - group: aspect-ratio
+    features:
+      - html.elements.video.aspect_ratio_computed_from_attributes
+      - html.elements.img.aspect_ratio_computed_from_attributes
+      - css.properties.aspect-ratio
+      - css.properties.aspect-ratio.auto
 authors:
   - denisputnov
 contributors:

--- a/css/backdrop/index.md
+++ b/css/backdrop/index.md
@@ -1,6 +1,10 @@
 ---
 title: "`::backdrop`"
 description: "Стилизуем подложку под всплывающими элементами."
+baseline:
+  - group: backdrop
+    features:
+      - css.selectors.backdrop
 authors:
   - solarrust
 contributors:

--- a/css/background-attachment/index.md
+++ b/css/background-attachment/index.md
@@ -1,6 +1,14 @@
 ---
 title: "`background-attachment`"
 description: "Одним свойством создаём эффектный параллакс."
+baseline:
+  - group: background-attachment
+    features:
+      - css.properties.background-attachment
+      - css.properties.background-attachment.fixed
+      - css.properties.background-attachment.local
+      - css.properties.background-attachment.scroll
+      - css.properties.background-attachment.multiple_backgrounds
 authors:
   - doka-dog
 keywords:

--- a/css/clip-path/index.md
+++ b/css/clip-path/index.md
@@ -1,6 +1,21 @@
 ---
 title: "`clip-path`"
 description: "Красиво и быстро задаём элементу любую форму при помощи всего одного CSS-свойства."
+baseline:
+  - group: clip-path
+    features:
+      - css.properties.clip-path
+      - css.properties.clip-path.basic_shape
+      - css.properties.clip-path.html_elements
+      - css.properties.clip-path.path
+      - css.properties.clip-path.svg_elements
+      - svg.global_attributes.clip-path
+      - api.SVGClipPathElement
+      - api.SVGClipPathElement.clipPathUnits
+      - api.SVGClipPathElement.transform
+      - svg.elements.clipPath
+      - svg.elements.clipPath.clipPathUnits
+      - svg.elements.clipPath.systemLanguage
 authors:
   - spheno
   - starhamster

--- a/css/color-scheme/index.md
+++ b/css/color-scheme/index.md
@@ -1,6 +1,16 @@
 ---
 title: "`color-scheme`"
 description: "Тёмная или светлая тема? Вы сами можете её задать!"
+baseline:
+  - group: color-scheme
+    features:
+      - html.elements.meta.name.color-scheme
+      - css.properties.color-scheme
+      - css.properties.color-scheme.only_dark
+      - css.properties.color-scheme.only_light
+      - css.properties.color-scheme.dark
+      - css.properties.color-scheme.light
+      - css.properties.color-scheme.normal
 authors:
   - anastasiayarosh
 keywords:

--- a/css/column-span/index.md
+++ b/css/column-span/index.md
@@ -1,6 +1,12 @@
 ---
 title: "`column-span`"
 description: "Нарушаем правила колоночной вёрстки и растягиваем элемент сразу на несколько колонок."
+baseline:
+  - group: column-span
+    features:
+      - css.properties.column-span
+      - css.properties.column-span.all
+      - css.properties.column-span.none
 authors:
   - xpleesid
 related:

--- a/css/conic-gradient/index.md
+++ b/css/conic-gradient/index.md
@@ -1,6 +1,11 @@
 ---
 title: "`conic-gradient()`"
 description: "CSS-функция создаёт конический градиент — фоновое изображение из цветовых переходов, повёрнутых вокруг центральной точки. Формы записи и примеры использования функции."
+baseline:
+  - group: conic-gradients
+    features:
+      - css.types.gradient.conic-gradient
+      - css.types.gradient.conic-gradient.doubleposition
 authors:
   - mitorun
 related:

--- a/css/layer/index.md
+++ b/css/layer/index.md
@@ -1,6 +1,16 @@
 ---
 title: "`@layer`"
 description: "Управляем каскадными слоями своими руками."
+baseline:
+  - group: cascade-layers
+    features:
+      - api.CSSImportRule.layerName
+      - api.CSSLayerBlockRule
+      - api.CSSLayerBlockRule.name
+      - api.CSSLayerStatementRule
+      - api.CSSLayerStatementRule.nameList
+      - css.at-rules.import.layer
+      - css.at-rules.layer
 authors:
   - tatianafokina
 contributors:

--- a/css/repeating-conic-gradient/index.md
+++ b/css/repeating-conic-gradient/index.md
@@ -1,6 +1,10 @@
 ---
 title: "`repeating-conic-gradient()`"
 description: "Всего одна функция для повторяющегося конического градиента!"
+baseline:
+  - group: conic-gradients
+    features:
+      - css.types.gradient.repeating-conic-gradient
 authors:
   - solarrust
 related:

--- a/html/dialog/index.md
+++ b/html/dialog/index.md
@@ -1,6 +1,17 @@
 ---
 title: "`<dialog>`"
 description: "Тег для создания всплывающего окна без боли и страданий."
+baseline:
+  - group: dialog
+    features:
+      - api.HTMLDialogElement
+      - api.HTMLDialogElement.close
+      - api.HTMLDialogElement.open
+      - api.HTMLDialogElement.returnValue
+      - api.HTMLDialogElement.show
+      - api.HTMLDialogElement.showModal
+      - html.elements.dialog
+      - html.elements.dialog.open
 authors:
   - baileys-li
 contributors:


### PR DESCRIPTION
## Описание

![image](https://github.com/user-attachments/assets/b2b0e33e-111d-44cb-bacc-1f53673a748c)

Добавляет конфигурацию baseline к докам:
- css/appearance
- css/aspect-ratio
- css/backdrop
- css/background-attachment
- css/clip-path
- css/color-scheme
- css/column-span
- css/conic-gradient
- css/layer
- css/repeating-conic-gradient
- html/dialog

Эти фичи перешли в разряд широко поддерживаемых за период 2023-2024
Источник: https://web-platform-dx.github.io/web-features-explorer/widely-available/

Тестировал локально с версией web-features 2.22.0

## Чек-лист

- [x] Текст оформлен [согласно руководству по стилю](https://github.com/doka-guide/content/blob/main/docs/styleguide.md)
- [x] Ссылки на внутренние материалы начинаются со слеша и заканчиваются слэшем либо якорем на заголовок (`/css/color/`, `/tools/json/`, `/tools/gulp/#kak-ponyat`)
- [x] Ссылки на картинки, видео и демки относительные (`images/example.png`, `demos/example/`, `../demos/example/`)
