### PR TITLE
Добавляет `isDisjointFrom()` в индекс JS

### DIFF
--- a/js/index.md
+++ b/js/index.md
@@ -154,6 +154,7 @@ groups:
       - set-symmetric-difference
       - set-is-subset-of
       - set-is-superset-of
+      - set-is-disjoint-from
   - name: "Обработка исключений"
     items:
       - try-catch


### PR DESCRIPTION
## Описание

Добавляет доку про метод `Set.isDisjointFrom()` в раздел JS

## Чек-лист

<!-- Список для самопроверки. Поможет вам подготовить пулреквест для быстрого мёрджа. Часть пунктов может быть неактуальна для вашей задачи, просто отметьте их как сделанные -->

- [x] Текст оформлен [согласно руководству по стилю](https://github.com/doka-guide/content/blob/main/docs/styleguide.md)
- [x] Ссылки на внутренние материалы начинаются со слеша и заканчиваются слэшем либо якорем на заголовок (`/css/color/`, `/tools/json/`, `/tools/gulp/#kak-ponyat`)
- [x] Ссылки на картинки, видео и демки относительные (`images/example.png`, `demos/example/`, `../demos/example/`)
