### PR TITLE
Исправляет пример в доке `caret-color`

### DIFF
--- a/css/caret-color/index.md
+++ b/css/caret-color/index.md
@@ -58,9 +58,8 @@ tags:
 <form>
   <input type="text">
   <textarea cols="30" rows="10"></textarea>
+  <p contenteditable>Зелёная каретка</p>
 </form>
-
-<p contenteditable>Зелёная каретка</p>
 ```
 
 ```css

--- a/css/caret-color/index.md
+++ b/css/caret-color/index.md
@@ -58,8 +58,9 @@ tags:
 <form>
   <input type="text">
   <textarea cols="30" rows="10"></textarea>
-  <p contenteditable>Зелёная каретка</p>
 </form>
+
+<p contenteditable>Зелёная каретка</p>
 ```
 
 ```css
@@ -67,11 +68,11 @@ form {
   caret-color: #FF8630;
 }
 
-form textarea {
+textarea {
   caret-color: #2E9AFF;
 }
 
-form p {
+p {
   caret-color: #F498AD;
 }
 ```


### PR DESCRIPTION
## Описание

Тег `p` должен быть внутри формы.

## Чек-лист

<!-- Список для самопроверки. Поможет вам подготовить пулреквест для быстрого мёрджа. Часть пунктов может быть неактуальна для вашей задачи, просто отметьте их как сделанные -->

- [x] Текст оформлен [согласно руководству по стилю](https://github.com/doka-guide/content/blob/main/docs/styleguide.md)
- [x] Ссылки на внутренние материалы начинаются со слеша и заканчиваются слэшем либо якорем на заголовок (`/css/color/`, `/tools/json/`, `/tools/gulp/#kak-ponyat`)
- [x] Ссылки на картинки, видео и демки относительные (`images/example.png`, `demos/example/`, `../demos/example/`)
