### PR TITLE
Добавляет информацию baseline для фич с неполной поддержкой

### DIFF
--- a/a11y/prefers-contrast/index.md
+++ b/a11y/prefers-contrast/index.md
@@ -1,6 +1,10 @@
 ---
 title: "`prefers-contrast`"
 description: "Значение директивы `@media`, которое отслеживает настройки контрастности."
+baseline:
+  - group: prefers-contrast
+    features:
+      - css.at-rules.media.prefers-contrast
 authors:
   - ra1nbow1
 contributors:

--- a/css/accent-color/index.md
+++ b/css/accent-color/index.md
@@ -1,6 +1,10 @@
 ---
 title: "`accent-color`"
 description: "Современный способ стилизовать чекбоксы, радиокнопки и другие контролы формы"
+baseline:
+  - group: accent-color
+    features:
+      - css.properties.accent-color
 authors:
   - solarrust
 contributors:

--- a/css/light-dark/index.md
+++ b/css/light-dark/index.md
@@ -1,6 +1,10 @@
 ---
 title: "`light-dark()`"
 description: "Задаём цвет в зависимости от темы операционной системы пользователя."
+baseline:
+  - group: light-dark
+    features:
+      - css.types.color.light-dark
 authors:
   - kozlovtseva
 related:

--- a/css/marker/index.md
+++ b/css/marker/index.md
@@ -1,6 +1,10 @@
 ---
 title: "`::marker`"
 description: "Псевдоэлемент для работы с маркерами элементов списка."
+baseline:
+  - group: marker
+    features:
+      - css.selectors.marker.animation_and_transition_support
 authors:
   - blueingreen68
 contributors:
@@ -98,8 +102,6 @@ li::marker {
 <aside>
 
 ⚠️ В Safari на данный момент псевдоэлемент `::marker` поддерживается не полностью. Нормально работает только свойство `color` и свойства для работы с текстом. Точно не работают свойства `content` и `direction`. А также отсутствует поддержка анимаций и переходов.
-
-Помимо Safari, анимации и переходы не поддерживаются в Firefox на Android.
 
 </aside>
 

--- a/css/scrollbar-color/index.md
+++ b/css/scrollbar-color/index.md
@@ -1,6 +1,10 @@
 ---
 title: "`scrollbar-color`"
 description: "Изменяем цвет полосы прокрутки."
+baseline:
+  - group: scrollbar-color
+    features:
+      - css.properties.scrollbar-color
 authors:
   - xpleesid
 keywords:

--- a/css/starting-style/index.md
+++ b/css/starting-style/index.md
@@ -1,6 +1,10 @@
 ---
 title: "`@starting-style`"
 description: "Директива для описания начальных стилей элемента в момент его появления на экране."
+baseline:
+  - group: starting-style
+    features:
+      - css.at-rules.starting-style
 authors:
   - akhmadullin
 related:

--- a/html/inert/index.md
+++ b/html/inert/index.md
@@ -1,6 +1,10 @@
 ---
 title: "Атрибут `inert`"
 description: "Элемент бездельничает? Не беда, ведь есть inert."
+baseline:
+  - group: inert
+    features:
+      api.HTMLElement.inert.ignores_find_in_page
 authors:
   - tatianafokina
 contributors:

--- a/js/element-touch/index.md
+++ b/js/element-touch/index.md
@@ -1,6 +1,13 @@
 ---
 title: "`touch`"
 description: "Сенсорные экраны отправляют не только событие клика, но и собственное — `touch`."
+baseline:
+  - group: touch-events
+    features:
+      - api.Element.touchcancel_event
+      - api.Element.touchend_event
+      - api.Element.touchmove_event
+      - api.Element.touchstart_event
 authors:
   - windrushfarer
 contributors:


### PR DESCRIPTION
## Описание

### Добавляет информацию baseline к докам:
#### Частичная поддержка
- accent-color
- ::marker
- scrollbar-color
- @starting-style
- inert
- touch

#### Полная поддержка
- light-dark
- prefers-contrast

Источник: https://web-platform-dx.github.io/web-features-explorer/one-missing-engine/

## Чек-лист

<!-- Список для самопроверки. Поможет вам подготовить пулреквест для быстрого мёрджа. Часть пунктов может быть неактуальна для вашей задачи, просто отметьте их как сделанные -->

- [x] Текст оформлен [согласно руководству по стилю](https://github.com/doka-guide/content/blob/main/docs/styleguide.md)
- [x] Ссылки на внутренние материалы начинаются со слеша и заканчиваются слэшем либо якорем на заголовок (`/css/color/`, `/tools/json/`, `/tools/gulp/#kak-ponyat`)
- [x] Ссылки на картинки, видео и демки относительные (`images/example.png`, `demos/example/`, `../demos/example/`)
