### PR TITLE
Корректирует пример в доке `:disabled, :enabled `

### DIFF
--- a/css/disabled-enabled/index.md
+++ b/css/disabled-enabled/index.md
@@ -29,7 +29,7 @@ tags:
 
 ```css
 button:disabled {
-    opacity: 0.5;
+  opacity: 0.5;
 }
 ```
 


### PR DESCRIPTION
## Описание

Заменил отступ перед свойством в 2 таба, на отступ в 1 таб, как во всех других примерах.

<!-- Кратко опишите изменение -->

## Чек-лист

<!-- Список для самопроверки. Поможет вам подготовить пулреквест для быстрого мёрджа. Часть пунктов может быть неактуальна для вашей задачи, просто отметьте их как сделанные -->

- [+] Текст оформлен [согласно руководству по стилю](https://github.com/doka-guide/content/blob/main/docs/styleguide.md)
- [+] Ссылки на внутренние материалы начинаются со слеша и заканчиваются слэшем либо якорем на заголовок (`/css/color/`, `/tools/json/`, `/tools/gulp/#kak-ponyat`)
- [+] Ссылки на картинки, видео и демки относительные (`images/example.png`, `demos/example/`, `../demos/example/`)
