### PR TITLE
Добавляет рецепт "Создание github-плитки"

### DIFF
--- a/recipes/github-contributes-heatmap/demos/commit-activity-demo/index.html
+++ b/recipes/github-contributes-heatmap/demos/commit-activity-demo/index.html
@@ -1,0 +1,318 @@
+<!DOCTYPE html>
+<html lang="ru">
+<head>
+  <title>DEMO — ARTICLE — Дока</title>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Roboto:wght@400;500&display=swap">
+  <style>
+    html {
+      color-scheme: dark;
+    }
+
+    body {
+      min-height: 100vh;
+      padding: 50px;
+      display: flex;
+      align-items: center;
+      justify-content: center;
+      background-color: #18191C;
+      color: #FFFFFF;
+      font-family: "Roboto", sans-serif;
+    }
+
+    .main-container {
+      display: flex;
+      flex-direction: column;
+      position: relative;
+    }
+
+    .description {
+      margin: 0 1rem;
+      font-size: 1.5rem;
+      color: #2e8b57;
+    }
+
+    .repo-name {
+      margin: 0 1rem 0 .5rem;
+      font-size: 1.5rem;
+      color: #5dd55d;
+    }
+
+    .year {
+      display: flex;
+      margin: 1rem;
+    }
+    .week {
+      display: flex;
+      flex-direction: column;
+      flex: 0 0 auto;
+    }
+    .day {
+      width: 14px;
+      height: 14px;
+      margin: 1px;
+      border: 1px solid #282828;
+      border-radius: 4px;
+    }
+    .day:hover {
+      border: 1px solid #555;
+    }
+    .cell {
+      background-color: #28e628;
+    }
+    .tooltip {
+      position: absolute;
+      width: max-content;
+      max-width: 400px;
+      padding: 8px 16px;
+      border-radius: 4px;
+      background-color: #555;
+      color: #FFF;
+    }
+    .hidden {
+      visibility: hidden;
+    }
+
+  </style>
+</head>
+<body>
+  <div id="repoGridContainer" class="main-container">
+    <div class="description hidden">
+      <span class="repo-label">
+        Репозиторий:
+      </span>
+      <span class="repo-name" />
+    </div>
+
+    <div
+      class="tooltip hidden"
+      role="tooltip"
+      id="tooltip"
+      data-position="top"
+    />
+  </div>
+
+  <script>
+    const GITHUB_REPO_API = 'https://api.github.com/repos'
+    const REPO = 'doka-guide/content'
+    const DATE_FORMATTER = new Intl.DateTimeFormat('ru', {
+      //weekday: 'long',
+      year: 'numeric',
+      month: 'numeric',
+      day: 'numeric',
+    })
+    const COLOR_MAX_STEPS = 10
+    const COLOR_MIN_STEPS = 5
+    const BASE_HSL = [90.5, 100, 49.4]
+
+    function requestGitHubData(url){
+      try {
+        return fetch(url, {
+          method: 'GET',
+          headers: {
+            'Accept': 'application/vnd.github+json',
+            'X-GitHub-Api-Version': '2022-11-28'
+          }
+        })
+      } catch (error) {
+        console.error(error)
+        return []
+      }
+    }
+
+    function createURL() {
+      return `${GITHUB_REPO_API}/${REPO}/stats/commit_activity`
+    }
+
+    function getWeekDate(weekTimestamp) {
+      return new Date(weekTimestamp * 1000)
+    }
+
+    function getDateFormat(date) {
+      return DATE_FORMATTER.format(date)
+    }
+
+    function parseCommits(responseData = []) {
+      if (!Array.isArray(responseData)) {
+        return []
+      }
+
+      return responseData.map(item => {
+        const { days, total, week } = item
+        const weekStartDate = getWeekDate(week)
+        const day = weekStartDate.getDate()
+
+        return {
+          days: days.map((count, dayIndex) => {
+            const newDate = weekStartDate.setDate(day + dayIndex)
+            const date = getDateFormat(newDate)
+            return {
+              count,
+              date
+            }
+          })
+        }
+      })
+    }
+
+    function analyzeCounts(data) {
+      const {min, max} = data.reduce((acc, weekData) => {
+        const counts = weekData.days.map(item => item.count)
+        acc.min = Math.min(...counts, acc.min)
+        acc.max = Math.max(...counts, acc.max)
+        return acc
+      }, {min: Number.POSITIVE_INFINITY, max: 0})
+
+      let steps = Math.max(Math.min(max, COLOR_MAX_STEPS), 1)
+      const stepSize = max / steps
+
+      return { min, max, steps: Math.max(steps, COLOR_MIN_STEPS), stepSize }
+    }
+
+    function generatePalette(hsl, steps) {
+      const [h, s, lBase] = hsl
+      const palette = []
+
+      for (let i = 0; i < steps; i++) {
+        let l = lBase - (lBase * i) / (steps - 1)
+        l = Math.max(0, l)
+        palette.push(`hsl(${h}, ${s}%, ${Math.round(l)}%)`)
+      }
+
+      return palette.reverse()
+    }
+
+    function makeColors(countsInfo) {
+      const {steps} = countsInfo
+
+      return generatePalette(BASE_HSL, steps)
+    }
+
+    function renderRepoInfo({repoName}) {
+      const description = parentContainer.querySelector('.description')
+      description.classList.remove('hidden')
+      const repoElem = description.querySelector('.repo-name')
+      repoElem.innerText=`${repoName}`
+    }
+
+    function renderYearGrid(params, parentContainer) {
+      const {data = [], countsInfo = {}, colors = []} = params
+      const columns = data.length ?? 0
+      if (columns === 0) return
+
+      const divider = Math.max(countsInfo.max, countsInfo.steps)
+      const factor = countsInfo.steps - 1
+
+      const yearContainer = document.createElement('div')
+      yearContainer.className = 'year'
+
+      data.forEach(weekData => {
+        const weekContainer = document.createElement('div')
+        weekContainer.className = 'week'
+
+        weekData.days.forEach(dayData => {
+          const {count, date} = dayData
+          let colorIndex = count > 0
+            ? Math.ceil((count / divider) * factor)
+            : 0
+
+          const dayContainer = document.createElement('div')
+          dayContainer.className = 'day cell'
+          dayContainer.style.background = colors[colorIndex]
+          dayContainer.setAttribute('data-date', date)
+          if (count) {
+            dayContainer.setAttribute('data-count', count)
+          }
+          weekContainer.appendChild(dayContainer)
+        })
+
+        yearContainer.appendChild(weekContainer)
+      })
+
+      parentContainer.appendChild(yearContainer)
+      return yearContainer
+    }
+
+    function bindTooltipEvent(yearGrid, parentContainer) {
+      if (! yearGrid || ! parentContainer) return
+
+      const tooltip = parentContainer.querySelector('.tooltip')
+
+      if (! tooltip) return
+
+      let top = 0
+      let left = 0
+
+      const toggleTooltip = (target = null) => {
+        const show = target !== null
+
+        if (show) {
+          const {offsetTop, offsetLeft} = target
+          const date = target.getAttribute('data-date')
+          const count = target.getAttribute('data-count')
+
+          tooltip.style.top = `${offsetTop - 40}px`
+          tooltip.style.left = `${offsetLeft - (count ? 90 : 45)}px`
+
+          tooltip.innerText = `${date}${count ? `, коммитов: ${count}` : ''}`
+        }
+
+        tooltip.classList.toggle('hidden', ! show)
+      }
+
+      const showTooltip = event => {
+        const target = event.target
+        if (target.classList.contains('day')) {
+          if (top !== target.offsetTop || left !== target.offsetLeft)
+          {
+            top = target.offsetTop
+            left = target.offsetLeft
+            toggleTooltip(target)
+          }
+        }
+      }
+
+      const hideTooltip = event => {
+        top = 0
+        left = 0
+        toggleTooltip()
+      }
+
+
+      yearGrid.addEventListener('mousemove', showTooltip)
+      yearGrid.addEventListener('mouseleave', hideTooltip)
+    }
+
+    async function fetchCommitStat() {
+      try {
+        let url = createURL()
+
+        const response = await requestGitHubData(url)
+        if (response.ok) {
+          return await response.json()
+        }
+
+      } catch (error) {
+        console.error(error)
+      }
+    }
+
+    const parentContainer = document.querySelector('#repoGridContainer')
+
+    fetchCommitStat().then(responseData => {
+      return parseCommits(responseData)
+    }).then(data => {
+      const countsInfo = analyzeCounts(data)
+      const colors = makeColors(countsInfo)
+
+      renderRepoInfo({repoName: REPO}, parentContainer)
+      const yearGrid = renderYearGrid({data, countsInfo, colors}, parentContainer)
+
+      bindTooltipEvent(yearGrid, parentContainer)
+    })
+  </script>
+</body>
+</html>


### PR DESCRIPTION
## Описание

Рецепт создания github-плитки активности репозитория

Текущее состояние: draft.
Работа над описанием рецепта - в процессе.
Вопросы (нужно/лишнее):
- возможность ввода имени репозитория ?
- возможность выбора цвета ?
- отображение при ответе сервера 202

![изображение](https://github.com/user-attachments/assets/0e01d923-b9f6-4bee-a8f6-1d8c668524d3)

## Чек-лист

<!-- Список для самопроверки. Поможет вам подготовить пулреквест для быстрого мёрджа. Часть пунктов может быть неактуальна для вашей задачи, просто отметьте их как сделанные -->

- [ ] Текст оформлен [согласно руководству по стилю](https://github.com/doka-guide/content/blob/main/docs/styleguide.md)
- [ ] Ссылки на внутренние материалы начинаются со слеша и заканчиваются слэшем либо якорем на заголовок (`/css/color/`, `/tools/json/`, `/tools/gulp/#kak-ponyat`)
- [ x] Ссылки на картинки, видео и демки относительные (`images/example.png`, `demos/example/`, `../demos/example/`)
