### PR TITLE
Исправляет вычисление полученной части в примере использования fetch

### DIFF
--- a/js/fetch/practice/windrushfarer.md
+++ b/js/fetch/practice/windrushfarer.md
@@ -91,8 +91,10 @@ fetch('https://i.imgur.com/C5QXZ7u.mp4').then(async (response) => {
       break
     }
 
-    received += value.length / contentLength * 100
+    received += (value.length / contentLength) * 100
+
     const result = Math.floor(received)
+
     if (result < 100) {
       console.log(`Получено ${result}%`)
     }

--- a/js/fetch/practice/windrushfarer.md
+++ b/js/fetch/practice/windrushfarer.md
@@ -91,9 +91,11 @@ fetch('https://i.imgur.com/C5QXZ7u.mp4').then(async (response) => {
       break
     }
 
-    received += Math.ceil(contentLength / value.length)
-
-    console.log(`Получено ${received}%`)
+    received += value.length / contentLength * 100
+    const result = Math.floor(received)
+    if (result < 100) {
+      console.log(`Получено ${result}%`)
+    }
   }
 })
 ```


### PR DESCRIPTION
## Описание
🔴 В текущем варинате в консоли отображаются неправильные значения:
![image](https://github.com/user-attachments/assets/71b3d10c-8a4f-43f2-959a-4492c2831cba)


Исправляет вычисление и показ полученной части файла:
- значение полученной части вычисляем как процент:

```js
received += value.length / contentLength * 100
```
- округление применяем только для показа значения:

```js
const result = Math.floor(received)
if (result < 100) {
  console.log(`Получено ${result}%`)
}
```

Closes #5759

## Чек-лист

<!-- Список для самопроверки. Поможет вам подготовить пулреквест для быстрого мёрджа. Часть пунктов может быть неактуальна для вашей задачи, просто отметьте их как сделанные -->

- [x] Текст оформлен [согласно руководству по стилю](https://github.com/doka-guide/content/blob/main/docs/styleguide.md)
- [x] Ссылки на внутренние материалы начинаются со слеша и заканчиваются слэшем либо якорем на заголовок (`/css/color/`, `/tools/json/`, `/tools/gulp/#kak-ponyat`)
- [x] Ссылки на картинки, видео и демки относительные (`images/example.png`, `demos/example/`, `../demos/example/`)
