### PR TITLE
Добавляет baseline и убирает упоминание об отсутствии поддержки в доку `text-decoration-thickness`

### DIFF
--- a/css/text-decoration-thickness/index.md
+++ b/css/text-decoration-thickness/index.md
@@ -1,8 +1,17 @@
 ---
 title: "`text-decoration-thickness`"
 description: "Какой будет толщина декоративной линии под (или над) текстом?"
+baseline:
+  - group: text-decoration
+    features:
+      - css.properties.text-decoration-thickness
+      - css.properties.text-decoration-thickness.auto
+      - css.properties.text-decoration-thickness.from-font
+      - css.properties.text-decoration-thickness.percentage
 authors:
   - nailheart
+contributors:
+  - vitya-ne
 keywords:
   - толщина декоративной линии
 related:
@@ -58,8 +67,6 @@ tags:
 - `auto` — значение по умолчанию, браузер сам определит толщину линии.
 - `from-font` — если в файле шрифта прописана предпочтительная толщина декоративной линии, то будет использована она. Если нет, то значение будет установлено в `auto`.
 - Толщина в единицах измерения — можно задать толщину линии во всех доступных [единицах измерения](/css/numeric-types/).
-
-Обратите внимание, что толщина в **процентах** поддерживается не всеми браузерами. Подробнее на [Can I use](https://caniuse.com/mdn-css_properties_text-decoration-thickness_percentage).
 
 ## Подсказки
 


### PR DESCRIPTION
## Описание
Добавляет baseline и убирает упоминание об отсутствии поддержки использования процентов как значения `text-decoration-thickness`.
Проценты поддерживаются всеми основными браузерами:
[Ссылка на конфиг baseline](https://github.com/web-platform-dx/web-features/blob/main/features/text-decoration.yml.dist)
![image](https://github.com/user-attachments/assets/19bcbd13-887b-4542-a72b-d85e7ad1420d)


## Чек-лист

<!-- Список для самопроверки. Поможет вам подготовить пулреквест для быстрого мёрджа. Часть пунктов может быть неактуальна для вашей задачи, просто отметьте их как сделанные -->

- [x] Текст оформлен [согласно руководству по стилю](https://github.com/doka-guide/content/blob/main/docs/styleguide.md)
- [x] Ссылки на внутренние материалы начинаются со слеша и заканчиваются слэшем либо якорем на заголовок (`/css/color/`, `/tools/json/`, `/tools/gulp/#kak-ponyat`)
- [x] Ссылки на картинки, видео и демки относительные (`images/example.png`, `demos/example/`, `../demos/example/`)
