### PR TITLE
Исправляет опечатку в доке 'preventDefault()'

### DIFF
--- a/js/event-prevent-default/practice/g-milevski.md
+++ b/js/event-prevent-default/practice/g-milevski.md
@@ -18,7 +18,7 @@
 const form = document.querySelector('.discount-form')
 form.addEventListener('submit', (event) => {
   event.preventDefault()
-  // Код по подготовки данных
+  // Код подготовки данных
   // и их отправка на сервер
 })
 ```


### PR DESCRIPTION
## Описание

Исправляет опечатку в  разделе 'На практике'

Closes #5819

## Чек-лист

- [x] Текст оформлен [согласно руководству по стилю](https://github.com/doka-guide/content/blob/main/docs/styleguide.md)
- [x] Ссылки на внутренние материалы начинаются со слеша и заканчиваются слэшем либо якорем на заголовок (`/css/color/`, `/tools/json/`, `/tools/gulp/#kak-ponyat`)
- [x] Ссылки на картинки, видео и демки относительные (`images/example.png`, `demos/example/`, `../demos/example/`)
