### PR TITLE
Добавляет новые доки в разделы СSS и HTML

### DIFF
--- a/css/index.md
+++ b/css/index.md
@@ -204,6 +204,8 @@ groups:
       - text-size-adjust
       - text-underline-offset
       - text-underline-position
+      - text-box-edge
+      - text-box-trim
       - word-break
       - word-spacing
       - word-wrap

--- a/html/index.md
+++ b/html/index.md
@@ -160,6 +160,7 @@ groups:
       - tabindex
       - enterkeyhint
       - data-attributes
+      - autofocus
   - name: 'Поисковая оптимизация'
     items:
       - seo-for-beginners


### PR DESCRIPTION
## Описание

Добавляет:
- CSS-доки в раздел 'Работа с текстом'
  - `text-box-edge`
  - `text-box-trim`
- HTML-доку в раздел 'Глобальные атрибуты':
  - `autofocus`


## Чек-лист

- [x] Текст оформлен [согласно руководству по стилю](https://github.com/doka-guide/content/blob/main/docs/styleguide.md)
- [x] Ссылки на внутренние материалы начинаются со слеша и заканчиваются слэшем либо якорем на заголовок (`/css/color/`, `/tools/json/`, `/tools/gulp/#kak-ponyat`)
- [x] Ссылки на картинки, видео и демки относительные (`images/example.png`, `demos/example/`, `../demos/example/`)
