### PR TITLE
Добавляет `*.code-workspace` в список исключений .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -68,6 +68,7 @@ dist
 ## Для редактора VSCode
 .vscode/*
 .history/
+*.code-workspace
 *.vsix
 .history
 .ionide


### PR DESCRIPTION
## Описание
VSCode создаёт и использует файлы `*.code-workspace`.
Эти файлы хрянят локальные настройки и не должны попадать в репозиторий.

Добавляю маску `*.code-workspace` в список исключений .gitignore

## Чек-лист

- [x] Текст оформлен [согласно руководству по стилю](https://github.com/doka-guide/content/blob/main/docs/styleguide.md)
- [x] Ссылки на внутренние материалы начинаются со слеша и заканчиваются слэшем либо якорем на заголовок (`/css/color/`, `/tools/json/`, `/tools/gulp/#kak-ponyat`)
- [x] Ссылки на картинки, видео и демки относительные (`images/example.png`, `demos/example/`, `../demos/example/`)
