### PR TITLE
Исправляет описание метода `URLSearchParams: forEach()`

### DIFF
--- a/js/urlsearchparams/index.md
+++ b/js/urlsearchparams/index.md
@@ -236,7 +236,7 @@ params.forEach((value, key, params) => {
 })
 // 10 count URLSearchParams { 'count' => '10', 'size' => 'lg', 'size' => 'xl' }
 // lg size URLSearchParams { 'count' => '10', 'size' => 'lg', 'size' => 'xl' }
-// xl size URLSearchParams { 'count' => '10', 'size' => 'lg', 'size' => 'xl' } 
+// xl size URLSearchParams { 'count' => '10', 'size' => 'lg', 'size' => 'xl' }
 ```
 
 ### Приведение параметров к строке

--- a/js/urlsearchparams/index.md
+++ b/js/urlsearchparams/index.md
@@ -226,14 +226,17 @@ console.log(params.toString())
 
 ### Перебор
 
-Метод `forEach()` перебирает значения, содержащиеся в поиске. Функция, переданная в метод, будет вызвана для каждого элемента в поиске и получит три аргумента – название параметра, значение параметра и сам экземпляр поиска.
+Метод `forEach()` перебирает значения, содержащиеся в поиске. Функция, переданная в метод, будет вызвана для каждого элемента в поиске и получит три аргумента – значение параметра, название параметра и сам экземпляр поиска.
 
 ```js
 const params = new URLSearchParams('count=10&size=lg&size=xl')
 
-params.forEach((key, value, params) => {
-  console.log(key, value, params)
+params.forEach((value, key, params) => {
+  console.log(value, key, params)
 })
+// 10 count URLSearchParams { 'count' => '10', 'size' => 'lg', 'size' => 'xl' }
+// lg size URLSearchParams { 'count' => '10', 'size' => 'lg', 'size' => 'xl' }
+// xl size URLSearchParams { 'count' => '10', 'size' => 'lg', 'size' => 'xl' } 
 ```
 
 ### Приведение параметров к строке


### PR DESCRIPTION
## Описание

Исправляет описание колбэк-функции метода `forEach()` экземпляра `URLSearchParams`.

Closes #5855

## Чек-лист

<!-- Список для самопроверки. Поможет вам подготовить пулреквест для быстрого мёрджа. Часть пунктов может быть неактуальна для вашей задачи, просто отметьте их как сделанные -->

- [x] Текст оформлен [согласно руководству по стилю](https://github.com/doka-guide/content/blob/main/docs/styleguide.md)
- [x] Ссылки на внутренние материалы начинаются со слеша и заканчиваются слэшем либо якорем на заголовок (`/css/color/`, `/tools/json/`, `/tools/gulp/#kak-ponyat`)
- [x] Ссылки на картинки, видео и демки относительные (`images/example.png`, `demos/example/`, `../demos/example/`)
