### PR TITLE
Исправляет демо свойства `scrollbar-gutter`

### DIFF
--- a/css/scrollbar-gutter/demos/bad/index.html
+++ b/css/scrollbar-gutter/demos/bad/index.html
@@ -181,6 +181,10 @@
       const openButton = document.querySelector('.open-button')
       const closeButton = document.querySelector('.close-button')
 
+      dialog.addEventListener('close', () => {
+        document.body.style.overflowY = 'auto'
+      })
+
       openButton.addEventListener('click', () => {
         dialog.showModal()
         document.body.style.overflowY = 'hidden'
@@ -188,7 +192,6 @@
 
       closeButton.addEventListener('click', () => {
         dialog.close()
-        document.body.style.overflowY = 'auto'
       })
     </script>
   </body>

--- a/css/scrollbar-gutter/demos/good/index.html
+++ b/css/scrollbar-gutter/demos/good/index.html
@@ -187,6 +187,10 @@
       const openButton = document.querySelector('.open-button')
       const closeButton = document.querySelector('.close-button')
 
+      dialog.addEventListener('close', () => {
+        document.body.style.overflowY = 'auto'
+      })
+
       openButton.addEventListener('click', () => {
         dialog.showModal()
         document.body.style.overflowY = 'hidden'
@@ -194,7 +198,6 @@
 
       closeButton.addEventListener('click', () => {
         dialog.close()
-        document.body.style.overflowY = 'auto'
       })
     </script>
   </body>


### PR DESCRIPTION
## Описание
В демо для свойству `scrollbar-gutter` при закрытии модалки клавишей esc не появлялся скролл у body

## Чек-лист

<!-- Список для самопроверки. Поможет вам подготовить пулреквест для быстрого мёрджа. Часть пунктов может быть неактуальна для вашей задачи, просто отметьте их как сделанные -->

- [x] Текст оформлен [согласно руководству по стилю](https://github.com/doka-guide/content/blob/main/docs/styleguide.md)
- [x] Ссылки на внутренние материалы начинаются со слеша и заканчиваются слэшем либо якорем на заголовок (`/css/color/`, `/tools/json/`, `/tools/gulp/#kak-ponyat`)
- [x] Ссылки на картинки, видео и демки относительные (`images/example.png`, `demos/example/`, `../demos/example/`)
