### PR TITLE
Адаптирует демки в `background-repeat`

### DIFF
--- a/css/border-block/demos/border-block-basic/index.html
+++ b/css/border-block/demos/border-block-basic/index.html
@@ -38,7 +38,12 @@
 
     @media (max-width: 768px) {
       body {
+        width: 100%;
         padding: 30px;
+      }
+
+      div {
+        width: 100%;
       }
     }
   </style>

--- a/css/border-block/demos/border-block-language-change/index.html
+++ b/css/border-block/demos/border-block-language-change/index.html
@@ -39,7 +39,12 @@
 
     @media (max-width: 768px) {
       body {
+        width: 100%;
         padding: 30px;
+      }
+
+      div {
+        width: 100%;
       }
     }
   </style>

--- a/css/border-block/demos/border-inline/index.html
+++ b/css/border-block/demos/border-inline/index.html
@@ -38,7 +38,12 @@
 
     @media (max-width: 768px) {
       body {
+        width: 100%;
         padding: 30px;
+      }
+
+      div {
+        width: 100%;
       }
     }
   </style>

--- a/css/border-block/demos/border-language-change/index.html
+++ b/css/border-block/demos/border-language-change/index.html
@@ -40,7 +40,12 @@
 
     @media (max-width: 768px) {
       body {
+        width: 100%;
         padding: 30px;
+      }
+
+      div {
+        width: 100%;
       }
     }
   </style>

--- a/css/border-block/demos/border-top-bottom/index.html
+++ b/css/border-block/demos/border-top-bottom/index.html
@@ -39,7 +39,12 @@
 
     @media (max-width: 768px) {
       body {
+        width: 100%;
         padding: 30px;
+      }
+
+      div {
+        width: 100%;
       }
     }
   </style>


### PR DESCRIPTION
## Описание

https://content-5904.dev.doka.guide/css/border-block/

Немного припорошил адоптивом: демки с иероглифами ломались на мобилках

\\^o^/

| Было | Стало |
| --- | --- |
| <img width="324" height="247" alt="image" src="https://github.com/user-attachments/assets/80966bf2-0324-44f0-8e43-4c2c8516ce9e" /> | <img width="340" height="250" alt="image" src="https://github.com/user-attachments/assets/777d1f02-8784-4848-8a21-f9bedcb41311" /> |
