### PR TITLE
Добавляет названия джобам

### DIFF
--- a/.github/workflows/pr-preview.yml
+++ b/.github/workflows/pr-preview.yml
@@ -22,7 +22,7 @@ jobs:
           echo "::set-output name=all::$returnReplaced"
           echo $returnReplaced
   pr-preview:
-    name: Превью
+    name: Сборка и загрузка превью
     runs-on: ubuntu-latest
     needs:
       - prepare


### PR DESCRIPTION
В одном из наших помёрженных PR #5905 случайно заметил, что у двух джоб нет названий:

<img width="1004" height="357" alt="image" src="https://github.com/user-attachments/assets/055ca2f5-f863-45f0-ae41-97f89565fbef" />

Предлагаю добавить им русские названия, чтобы в хронологии выполнения джоб всё было консистентно.