### PR TITLE
Исправляет ссылки в CSS-доках

### DIFF
--- a/css/color-mix/index.md
+++ b/css/color-mix/index.md
@@ -158,7 +158,7 @@ color-mix(in hsl increasing hue, red, blue);
 - [Именованные цвета (например, `red`, `blue`)](/css/web-colors/#nazvanie-cveta)
 - Функции: [`rgb()`](/css/web-colors/#rgb), [`rgba()`](/css/web-colors/#rgb), [`hsl()`](/css/web-colors/#hsl), [`hsla()`](/css/web-colors/#hsl), [`hwb()`](/css/web-colors/#hwb), `lab()`, `lch()`, `oklab()`, `oklch()`
 - Функция [`color()`](/css/color-function/)
-- [`transparent​`](/css/web-colors/#transparent​)
+- [`transparent​`](/css/web-colors/#transparent)
 
 **Нельзя передавать:​**
 

--- a/css/text-box-trim/index.md
+++ b/css/text-box-trim/index.md
@@ -56,7 +56,7 @@ tags:
 - `trim-end` — убирает снизу;
 - `trim-both` — убирает сверху и снизу.
 
-Можно использовать шорткат [`text-box`](css/text-box/), чтобы задать [`text-box-trim`](css/text-box-trim/) и `text-box-edge` одной строкой:
+Можно использовать шорткат [`text-box`](/css/text-box/), чтобы задать [`text-box-trim`](/css/text-box-trim/) и `text-box-edge` одной строкой:
 
 ```css
 .tip {


### PR DESCRIPTION
## Описание
Исправляет ссылки в доках:
- text-box-trim;
- color-mix();

Превью:
https://content-5950.dev.doka.guide/css/text-box-trim/
https://content-5950.dev.doka.guide/css/color-mix/

## Чек-лист

<!-- Список для самопроверки. Поможет вам подготовить пулреквест для быстрого мёрджа. Часть пунктов может быть неактуальна для вашей задачи, просто отметьте их как сделанные -->

- [ ] Текст оформлен [согласно руководству по стилю](https://github.com/doka-guide/content/blob/main/docs/styleguide.md)
- [ ] Ссылки на внутренние материалы начинаются со слеша и заканчиваются слэшем либо якорем на заголовок (`/css/color/`, `/tools/json/`, `/tools/gulp/#kak-ponyat`)
- [ ] Ссылки на картинки, видео и демки относительные (`images/example.png`, `demos/example/`, `../demos/example/`)
