### PR TITLE
Удаляет ошибочный код из примера в доке `concat()`

### DIFF
--- a/js/array-concat/index.md
+++ b/js/array-concat/index.md
@@ -159,8 +159,6 @@ console.log(numbers.concat([4, [5, 6]]))
 
   console.log(numbers.concat(arrayLike))
   // [1, 2, 3, 4, 5, 6]
-
-  console.log(numbers.concat({''}))
   ```
 
 </details>


### PR DESCRIPTION
## Описание

Удаляет лишнюю (путающую читателя и к тому же содержащую ошибку) строку из примера

Превью: https://content-5953.dev.doka.guide/js/array-concat/

## Чек-лист

<!-- Список для самопроверки. Поможет вам подготовить пулреквест для быстрого мёрджа. Часть пунктов может быть неактуальна для вашей задачи, просто отметьте их как сделанные -->

- [x] Текст оформлен [согласно руководству по стилю](https://github.com/doka-guide/content/blob/main/docs/styleguide.md)
- [x] Ссылки на внутренние материалы начинаются со слеша и заканчиваются слэшем либо якорем на заголовок (`/css/color/`, `/tools/json/`, `/tools/gulp/#kak-ponyat`)
- [x] Ссылки на картинки, видео и демки относительные (`images/example.png`, `demos/example/`, `../demos/example/`)
