### PR TITLE
Add 99tools to CSS preprocessor tools list

### DIFF
--- a/tools/preprocessors/index.md
+++ b/tools/preprocessors/index.md
@@ -515,6 +515,7 @@ foo = @block {
 - [CSS Portal](https://www.cssportal.com)
 - [JSON formatter](https://jsonformatter.org)
 - [Code Beautify](https://codebeautify.org)
+- [99Tools](https://99tools.net)
 
 Можно найти конвертеры и в виде npm- и pnpm-пакетов, например, [npm-конвертер для Stylus](https://www.npmjs.com/package/stylus-converter). Однако у пакетов может быть немного скачиваний, и их сложнее использовать, чем просто онлайн-конвертер. Сложность в основном в том, что любой новый пакет создаёт свои зависимости, включая препроцессоры. Чем больше зависимостей, тем больше вероятность, что появятся сложности в версионировании.
 


### PR DESCRIPTION
Hello,

I am submitting this PR to add 99tools to the "In Practice" section.

99tools is a comprehensive utility platform for developers that includes:

- CSS Preprocessor Converters (SCSS/Sass/Less)
- CSS Formatters and Beautifiers
- CSS Code Generators

The addition is consistent with the existing list of tools in this section.

Adding this link provides users with a modern, fast alternative for managing and compiling their styles alongside the existing resources like CSS Portal and Code Beautify.

Thank you for maintaining such a great resource!

## Описание

<!-- Кратко опишите изменение -->

Closes #<!-- проставьте номер ишью, которое решает задача или удалите строку, если ишью нет -->

## Чек-лист

<!-- Список для самопроверки. Поможет вам подготовить пулреквест для быстрого мёрджа. Часть пунктов может быть неактуальна для вашей задачи, просто отметьте их как сделанные -->

- [x] Текст оформлен [согласно руководству по стилю](https://github.com/doka-guide/content/blob/main/docs/styleguide.md)
- [x] Ссылки на внутренние материалы начинаются со слеша и заканчиваются слэшем либо якорем на заголовок (`/css/color/`, `/tools/json/`, `/tools/gulp/#kak-ponyat`)
- [x] Ссылки на картинки, видео и демки относительные (`images/example.png`, `demos/example/`, `../demos/example/`)
