### PR TITLE
Правит пример с debounce

### DIFF
--- a/js/debounce/demos/debounced-search/index.html
+++ b/js/debounce/demos/debounced-search/index.html
@@ -164,15 +164,19 @@
     const searchResults = document.querySelector('.search-results')
 
     function debounce(callee, timeoutMs) {
-      return function perform(...args) {
-        let previousCall = this.lastCall
-        this.lastCall = Date.now()
+      let lastCall
+      let previousCall
+      let lastCallTimer
 
-        if (previousCall && ((this.lastCall - previousCall) <= timeoutMs)) {
-          clearTimeout(this.lastCallTimer)
+      return function perform(...args) {
+        previousCall = lastCall
+        lastCall = Date.now()
+
+        if (previousCall && lastCall - previousCall <= timeoutMs) {
+          clearTimeout(lastCallTimer)
         }
 
-        this.lastCallTimer = setTimeout(() => callee(...args), timeoutMs)
+        lastCallTimer = setTimeout(() => callee(...args), timeoutMs)
       }
     }
 

--- a/js/debounce/index.md
+++ b/js/debounce/index.md
@@ -237,16 +237,19 @@ const server = {
 
 ```javascript
 function debounce(callee, timeoutMs) {
+  let lastCall
+  let previousCall
+  let lastCallTimer
+
   return function perform(...args) {
-    let previousCall = this.lastCall
+    previousCall = lastCall
+    lastCall = Date.now()
 
-    this.lastCall = Date.now()
-
-    if (previousCall && this.lastCall - previousCall <= timeoutMs) {
-      clearTimeout(this.lastCallTimer)
+    if (previousCall && lastCall - previousCall <= timeoutMs) {
+      clearTimeout(lastCallTimer)
     }
 
-    this.lastCallTimer = setTimeout(() => callee(...args), timeoutMs)
+    lastCallTimer = setTimeout(() => callee(...args), timeoutMs)
   }
 }
 ```


### PR DESCRIPTION
Closes: https://github.com/doka-guide/content/issues/5985

Я бы, конечно, заменил этот пример на более простой с учётом оригинальных условий:

```javascript
function debounce(fn, delay) {
  let timeout;
  return function (...args) {
    clearTimeout(timeout);
    timeout = setTimeout(() => { fn(...args) }, delay);
  };
}
```

Превью: https://content-6001.dev.doka.guide/js/debounce/#pishem-debounce