### PR TITLE
Обновляет группы в baseline для `shape()` и удаляет ненужные поля в `inputmode`

### DIFF
--- a/css/shape-function/index.md
+++ b/css/shape-function/index.md
@@ -2,7 +2,7 @@
 title: "`shape()`"
 description: "Создаём сложные формы с помощью команд, похожих на SVG, но с поддержкой CSS-единиц измерения."
 baseline:
-  - group: shape-function
+  - group: clipping-shapes-masking
     features:
       - css.types.basic-shape.shape
 authors:

--- a/html/inputmode/index.md
+++ b/html/inputmode/index.md
@@ -1,11 +1,6 @@
 ---
 title: "Атрибут `inputmode`"
 description: "Если нужно ввести только цифры зачем показывать всю клавиатуру? Подсказка для браузера какой набор символов нужен."
-baseline:
-  - group: inputmode
-    features:
-      - api.HTMLElement.inputMode
-      - html.global_attributes.inputmode
 authors:
   - webdb81
 contributors:


### PR DESCRIPTION
## Описание

При запуске платформы локально сборка падает из-за неправильного указания полей в baseline. Подозреваю, что это же влияет на сборку превью.
@vitya-ne не смогла найти правильной меты для `inputmode`, поэтому пока просто удалила. Можешь глянуть тоже, может я плохо смотрела.

## Чек-лист

<!-- Список для самопроверки. Поможет вам подготовить пулреквест для быстрого мёрджа. Часть пунктов может быть неактуальна для вашей задачи, просто отметьте их как сделанные -->

- [ ] Текст оформлен [согласно руководству по стилю](https://github.com/doka-guide/content/blob/main/docs/styleguide.md)
- [ ] Ссылки на внутренние материалы начинаются со слеша и заканчиваются слэшем либо якорем на заголовок (`/css/color/`, `/tools/json/`, `/tools/gulp/#kak-ponyat`)
- [ ] Ссылки на картинки, видео и демки относительные (`images/example.png`, `demos/example/`, `../demos/example/`)
