### PR TITLE
fix: Правит поведение линк-чекера внутри пиаров

### DIFF
--- a/.github/scripts/link-check.js
+++ b/.github/scripts/link-check.js
@@ -64,46 +64,113 @@ function maskNonLinkRegions(content) {
     .replace(/^---\n[\s\S]*?\n---/, maskRegion)
     .replace(/^```[^\n]*\n[\s\S]*?^```/gm, maskRegion)
     .replace(/^~~~[^\n]*\n[\s\S]*?^~~~/gm, maskRegion)
+    .replace(/`[^`\n]+`/g, maskRegion)
 }
 
 function cleanHeadingText(text) {
-  return text
+  // прячем код в бэктиках от чистки HTML-тегов ниже, иначе `<td>` в заголовке станет пустой строкой
+  const codeSpans = []
+  const withPlaceholders = text.replace(/`([^`]+)`/g, (_, code) => {
+    codeSpans.push(code)
+    return `\u0000${codeSpans.length - 1}\u0000`
+  })
+
+  const cleaned = withPlaceholders
     .replace(/!\[([^\]]*)\]\([^)]+\)/g, '$1')
     .replace(/\[([^\]]+)\]\([^)]+\)/g, '$1')
-    .replace(/`([^`]+)`/g, '$1')
     .replace(/\*\*([^*]+)\*\*/g, '$1')
     .replace(/\*([^*]+)\*/g, '$1')
     .replace(/<\/?[^>]+>/g, '')
     .replace(/\{#[^}]+\}/g, '')
+
+  return cleaned
+    .replace(/\u0000(\d+)\u0000/g, (_, i) => codeSpans[Number(i)])
     .trim()
+}
+
+function addAnchorWithDedupe(anchors, headingHashMap, headingText) {
+  if (!headingText) {
+    return
+  }
+
+  const id = slugify(headingText)
+  if (headingHashMap[id] >= 0) {
+    headingHashMap[id] += 1
+  } else {
+    headingHashMap[id] = 0
+  }
+
+  const postfix = headingHashMap[id] > 0 ? `-${headingHashMap[id]}` : ''
+  anchors.add(id + postfix)
 }
 
 function extractHeadingAnchors(content) {
   const anchors = new Set()
   const headingHashMap = {}
-  const body = content.replace(/^---[\s\S]*?---\n/, '')
+  const frontmatterMatch = content.match(/^---\n([\s\S]*?)\n---\n?/)
+  const frontmatter = frontmatterMatch ? frontmatterMatch[1] : ''
+  const body = frontmatterMatch ? content.slice(frontmatterMatch[0].length) : content
   const headingRegex = /^(#{2,6})\s+(.+)$/gm
   let match
 
   while ((match = headingRegex.exec(body)) !== null) {
-    const headingText = cleanHeadingText(match[2])
-    if (!headingText) {
-      continue
-    }
+    addAnchorWithDedupe(anchors, headingHashMap, cleanHeadingText(match[2]))
+  }
 
-    const id = slugify(headingText)
-    if (headingHashMap[id] >= 0) {
-      headingHashMap[id] += 1
-    } else {
-      headingHashMap[id] = 0
-    }
+  // хабы разделов (html/index.md и т. п.) без ## заголовков — структура задаётся YAML groups[].name
+  const groupNameRegex = /^\s*-\s*name:\s*['"]?(.+?)['"]?\s*$/gm
+  while ((match = groupNameRegex.exec(frontmatter)) !== null) {
+    addAnchorWithDedupe(anchors, headingHashMap, match[1].trim())
+  }
 
-    const postfix = headingHashMap[id] > 0 ? `-${headingHashMap[id]}` : ''
-    anchors.add(id + postfix)
+  const legacyAnchorRegex = /<a\s+name=["']([^"']+)["']/gi
+  while ((match = legacyAnchorRegex.exec(body)) !== null) {
+    anchors.add(match[1])
   }
 
   return anchors
 }
+
+// вопрос интервью через related: привязывается к статье и рендерит на ней
+// блок «На собеседовании» с якорем #na-sobesedovanii (см. doc.11tydata.js)
+function buildQuestionsByArticle() {
+  const articlesWithQuestions = new Set()
+  const interviewsRoot = path.join(ROOT, 'interviews')
+
+  if (!fs.existsSync(interviewsRoot)) {
+    return articlesWithQuestions
+  }
+
+  for (const entry of fs.readdirSync(interviewsRoot, { withFileTypes: true })) {
+    if (!entry.isDirectory()) {
+      continue
+    }
+
+    const content = readFile(path.join('interviews', entry.name, 'index.md'))
+    if (!content) {
+      continue
+    }
+
+    const frontmatterMatch = content.match(/^---\n([\s\S]*?)\n---/)
+    const relatedBlock = frontmatterMatch
+      && frontmatterMatch[1].match(/^related:\n((?:[ \t]*-[ \t]*.+\n?)*)/m)
+    if (!relatedBlock) {
+      continue
+    }
+
+    const relatedLines = relatedBlock[1].match(/^[ \t]*-[ \t]*(.+)$/gm) || []
+    for (const line of relatedLines) {
+      const relatedPath = line.replace(/^[ \t]*-[ \t]*/, '').trim().replace(/^\/+|\/+$/g, '')
+      if (relatedPath) {
+        articlesWithQuestions.add(relatedPath)
+      }
+    }
+  }
+
+  return articlesWithQuestions
+}
+
+const articlesWithQuestions = buildQuestionsByArticle()
 
 function getPersonName(nick, readFn = readFile) {
   const personFile = `people/${nick}/index.md`
@@ -167,6 +234,10 @@ function extractArticleAnchors(articleIndexPath, readFn = readFile) {
     }
   }
 
+  if (articlesWithQuestions.has(articleDir)) {
+    anchors.add('na-sobesedovanii')
+  }
+
   return anchors
 }
 
@@ -217,6 +288,10 @@ function splitUrl(url) {
   }
 }
 
+// платформенные роуты без index.md в контент-репо (корень сайта, /people/, /subscribe/ и т. п.)
+const PLATFORM_ROUTE = Symbol('platform-route')
+const PLATFORM_ROUTES = new Set(['/', '/people/', '/subscribe/'])
+
 function resolveArticleFile(pathname) {
   let cleanPath = pathname.split('?')[0]
   if (!cleanPath.startsWith('/')) {
@@ -226,6 +301,10 @@ function resolveArticleFile(pathname) {
   cleanPath = cleanPath.replace(/\/+/g, '/')
   if (!cleanPath.endsWith('/')) {
     cleanPath += '/'
+  }
+
+  if (PLATFORM_ROUTES.has(cleanPath)) {
+    return PLATFORM_ROUTE
   }
 
   if (pagesByLocation.has(cleanPath)) {
@@ -239,8 +318,7 @@ function resolveArticleFile(pathname) {
 
   const [section] = parts
   if (!SECTION_ROOTS.has(section)) {
-    // /about/, /subscribe/ и другие pages без префикса pages/
-    return null
+    return PLATFORM_ROUTE
   }
 
   if (parts.length === 1) {
@@ -262,12 +340,17 @@ function extractLinks(content) {
   // поэтому match.index указывает на позицию в исходном content
   const body = maskNonLinkRegions(content)
 
-  const markdownLinkRegex = /!?\[([^\]]*)\]\(([^)\s]+)\)/g
+  // текст ссылки для сообщений берём из content, а не body: в body он мог быть замаскирован
+  const rawAt = (index, length) => content.slice(index, index + length)
+
+  // вторая ветка — URL в угловых скобках, может содержать «)»: [текст](<url_с_(скобками)>)
+  const markdownLinkRegex = /!?\[([^\]]*)\]\(\s*<([^>]+)>\s*\)|!?\[([^\]]*)\]\(([^)\s]+)\)/g
   let match
   while ((match = markdownLinkRegex.exec(body)) !== null) {
+    const url = match[2] !== undefined ? match[2] : match[4]
     links.push({
-      url: match[2].trim(),
-      raw: match[0],
+      url: url.trim(),
+      raw: rawAt(match.index, match[0].length),
       index: match.index,
     })
   }
@@ -276,7 +359,7 @@ function extractLinks(content) {
   while ((match = attrRegex.exec(body)) !== null) {
     links.push({
       url: match[1].trim(),
-      raw: match[0],
+      raw: rawAt(match.index, match[0].length),
       index: match.index,
     })
   }
@@ -303,12 +386,13 @@ function shouldSkipUrl(url) {
 
 function resolveRelativeAsset(fromFile, url) {
   const { pathname } = splitUrl(url)
-  if (!pathname || pathname.startsWith('/')) {
+  const cleanPathname = pathname.split('?')[0]
+  if (!cleanPathname || cleanPathname.startsWith('/')) {
     return null
   }
 
   const baseDir = path.dirname(fromFile)
-  return path.normalize(path.join(baseDir, pathname))
+  return path.normalize(path.join(baseDir, cleanPathname))
 }
 
 function checkAssetExists(relativePath) {
@@ -399,6 +483,10 @@ function checkForwardLinks(filePath) {
 
     const { pathname, hash } = splitUrl(url)
     const targetFile = resolveArticleFile(pathname)
+
+    if (targetFile === PLATFORM_ROUTE) {
+      continue
+    }
 
     if (!targetFile) {
       fail(`${filePath}:${line} → нет материала по пути «${pathname}» (ссылка ${link.raw})`)

--- a/.github/scripts/link-check.js
+++ b/.github/scripts/link-check.js
@@ -1,0 +1,611 @@
+const fs = require('fs')
+const path = require('path')
+const { execSync } = require('child_process')
+const { slugify } = require('transliteration')
+
+const ROOT = process.cwd()
+
+const SECTION_ROOTS = new Set([
+  'a11y',
+  'css',
+  'html',
+  'js',
+  'tools',
+  'recipes',
+  'interviews',
+  'people',
+  'docs',
+])
+
+const errors = new Set()
+
+const args = process.argv.slice(2).filter((arg) => !arg.startsWith('--'))
+const baseSha = process.env.BASE_SHA || ''
+
+const changedFiles = args.length > 0
+  ? args
+  : (process.env.CHANGED_FILES || '')
+    .split(/[,\s]+/)
+    .map((file) => file.trim())
+    .filter(Boolean)
+
+function fail(message) {
+  if (errors.has(message)) {
+    return
+  }
+  errors.add(message)
+  console.error(`✖ ${message}`)
+}
+
+function readFile(filePath) {
+  const absolutePath = path.join(ROOT, filePath)
+  if (!fs.existsSync(absolutePath)) {
+    return null
+  }
+  return fs.readFileSync(absolutePath, 'utf8')
+}
+
+function readFileAtBase(filePath) {
+  if (!baseSha) {
+    return null
+  }
+
+  return runGit(['show', `${baseSha}:${filePath}`], { onError: () => null })
+}
+
+// затираем регион пробелами, сохраняя переносы строк, чтобы не съехали
+// смещения символов и номера строк оставались корректными
+function maskRegion(match) {
+  return match.replace(/[^\n]/g, ' ')
+}
+
+function maskNonLinkRegions(content) {
+  return content
+    .replace(/^---\n[\s\S]*?\n---/, maskRegion)
+    .replace(/^```[^\n]*\n[\s\S]*?^```/gm, maskRegion)
+    .replace(/^~~~[^\n]*\n[\s\S]*?^~~~/gm, maskRegion)
+}
+
+function cleanHeadingText(text) {
+  return text
+    .replace(/!\[([^\]]*)\]\([^)]+\)/g, '$1')
+    .replace(/\[([^\]]+)\]\([^)]+\)/g, '$1')
+    .replace(/`([^`]+)`/g, '$1')
+    .replace(/\*\*([^*]+)\*\*/g, '$1')
+    .replace(/\*([^*]+)\*/g, '$1')
+    .replace(/<\/?[^>]+>/g, '')
+    .replace(/\{#[^}]+\}/g, '')
+    .trim()
+}
+
+function extractHeadingAnchors(content) {
+  const anchors = new Set()
+  const headingHashMap = {}
+  const body = content.replace(/^---[\s\S]*?---\n/, '')
+  const headingRegex = /^(#{2,6})\s+(.+)$/gm
+  let match
+
+  while ((match = headingRegex.exec(body)) !== null) {
+    const headingText = cleanHeadingText(match[2])
+    if (!headingText) {
+      continue
+    }
+
+    const id = slugify(headingText)
+    if (headingHashMap[id] >= 0) {
+      headingHashMap[id] += 1
+    } else {
+      headingHashMap[id] = 0
+    }
+
+    const postfix = headingHashMap[id] > 0 ? `-${headingHashMap[id]}` : ''
+    anchors.add(id + postfix)
+  }
+
+  return anchors
+}
+
+function getPersonName(nick, readFn = readFile) {
+  const personFile = `people/${nick}/index.md`
+  const content = readFn(personFile)
+  if (!content) {
+    return nick
+  }
+
+  const nameMatch = content.match(/^name:\s*['"]?(.+?)['"]?\s*$/m)
+  return nameMatch ? nameMatch[1].trim() : nick
+}
+
+function listPracticeNicks(articleDir, readFn = readFile) {
+  const practiceDir = path.join(articleDir, 'practice')
+  const absoluteDir = path.join(ROOT, practiceDir)
+
+  if (readFn === readFile) {
+    if (!fs.existsSync(absoluteDir)) {
+      return []
+    }
+    return fs.readdirSync(absoluteDir)
+      .filter((file) => file.endsWith('.md'))
+      .map((file) => file.replace(/\.md$/, ''))
+  }
+
+  const output = runGit(['ls-tree', '--name-only', `${baseSha}:${practiceDir}`], {
+    onError: () => null,
+  })
+  if (output === null) {
+    return []
+  }
+
+  return output
+    .split('\n')
+    .map((line) => line.trim())
+    .filter((file) => file.endsWith('.md'))
+    .map((file) => file.replace(/\.md$/, ''))
+}
+
+function extractArticleAnchors(articleIndexPath, readFn = readFile) {
+  const anchors = new Set()
+  const content = readFn(articleIndexPath)
+
+  if (content) {
+    for (const anchor of extractHeadingAnchors(content)) {
+      anchors.add(anchor)
+    }
+  }
+
+  const articleDir = path.dirname(articleIndexPath)
+  const nicks = listPracticeNicks(articleDir, readFn)
+
+  if (nicks.length > 0) {
+    anchors.add('na-praktike')
+    anchors.add('practices')
+
+    for (const nick of nicks) {
+      anchors.add(`practices-${nick}`)
+      const personName = getPersonName(nick, readFn)
+      anchors.add(slugify(`${personName} советует`))
+    }
+  }
+
+  return anchors
+}
+
+function buildPagesLocationMap() {
+  const map = new Map()
+  const pagesRoot = path.join(ROOT, 'pages')
+
+  if (!fs.existsSync(pagesRoot)) {
+    return map
+  }
+
+  for (const entry of fs.readdirSync(pagesRoot, { withFileTypes: true })) {
+    if (!entry.isDirectory()) {
+      continue
+    }
+
+    const indexPath = path.join('pages', entry.name, 'index.md')
+    const content = readFile(indexPath)
+    if (!content) {
+      continue
+    }
+
+    const locationMatch = content.match(/^location:\s*['"]?([^'"\n]+)['"]?\s*$/m)
+    const location = locationMatch
+      ? locationMatch[1].trim().replace(/\/?$/, '/')
+      : `/${entry.name}/`
+
+    map.set(location, indexPath)
+  }
+
+  return map
+}
+
+const pagesByLocation = buildPagesLocationMap()
+
+function normalizeDokaUrl(url) {
+  if (url.startsWith('https://doka.guide')) {
+    return url.replace(/^https:\/\/doka\.guide/, '') || '/'
+  }
+  return url
+}
+
+function splitUrl(url) {
+  const [pathname, hash = ''] = url.split('#')
+  return {
+    pathname: pathname || '',
+    hash: hash || '',
+  }
+}
+
+function resolveArticleFile(pathname) {
+  let cleanPath = pathname.split('?')[0]
+  if (!cleanPath.startsWith('/')) {
+    return null
+  }
+
+  cleanPath = cleanPath.replace(/\/+/g, '/')
+  if (!cleanPath.endsWith('/')) {
+    cleanPath += '/'
+  }
+
+  if (pagesByLocation.has(cleanPath)) {
+    return pagesByLocation.get(cleanPath)
+  }
+
+  const parts = cleanPath.slice(1, -1).split('/').filter(Boolean)
+  if (parts.length === 0) {
+    return null
+  }
+
+  const [section] = parts
+  if (!SECTION_ROOTS.has(section)) {
+    // /about/, /subscribe/ и другие pages без префикса pages/
+    return null
+  }
+
+  if (parts.length === 1) {
+    const indexPath = path.join(section, 'index.md')
+    return readFile(indexPath) !== null ? indexPath : null
+  }
+
+  const indexPath = path.join(...parts, 'index.md')
+  if (readFile(indexPath) !== null) {
+    return indexPath
+  }
+
+  return null
+}
+
+function extractLinks(content) {
+  const links = []
+  // маскируем фронтматтер и код-блоки, но длина строки сохраняется,
+  // поэтому match.index указывает на позицию в исходном content
+  const body = maskNonLinkRegions(content)
+
+  const markdownLinkRegex = /!?\[([^\]]*)\]\(([^)\s]+)\)/g
+  let match
+  while ((match = markdownLinkRegex.exec(body)) !== null) {
+    links.push({
+      url: match[2].trim(),
+      raw: match[0],
+      index: match.index,
+    })
+  }
+
+  const attrRegex = /\b(?:href|src)=["']([^"']+)["']/gi
+  while ((match = attrRegex.exec(body)) !== null) {
+    links.push({
+      url: match[1].trim(),
+      raw: match[0],
+      index: match.index,
+    })
+  }
+
+  return links
+}
+
+function lineNumberAt(content, index) {
+  return content.slice(0, index).split('\n').length
+}
+
+function shouldSkipUrl(url) {
+  if (!url || url === '#') {
+    return true
+  }
+  if (url.startsWith('mailto:') || url.startsWith('tel:')) {
+    return true
+  }
+  if (url.startsWith('http://') || url.startsWith('https://')) {
+    return !url.startsWith('https://doka.guide')
+  }
+  return false
+}
+
+function resolveRelativeAsset(fromFile, url) {
+  const { pathname } = splitUrl(url)
+  if (!pathname || pathname.startsWith('/')) {
+    return null
+  }
+
+  const baseDir = path.dirname(fromFile)
+  return path.normalize(path.join(baseDir, pathname))
+}
+
+function checkAssetExists(relativePath) {
+  const absolutePath = path.join(ROOT, relativePath)
+  return fs.existsSync(absolutePath)
+}
+
+function articlePathnameFromFile(filePath) {
+  if (filePath.startsWith('pages/')) {
+    const content = readFile(filePath) || readFileAtBase(filePath)
+    const locationMatch = content && content.match(/^location:\s*['"]?([^'"\n]+)['"]?\s*$/m)
+    if (locationMatch) {
+      return locationMatch[1].trim().replace(/\/?$/, '/')
+    }
+    const slug = path.basename(path.dirname(filePath))
+    return `/${slug}/`
+  }
+
+  const dir = path.dirname(filePath).replace(/\\/g, '/')
+  return `/${dir}/`
+}
+
+// на страницах интервью id заголовков генерятся из <p> вопроса, а ответы
+// рендерятся внутри страницы вопроса и своего URL не имеют — модель якорей
+// у этого раздела другая, поэтому его материалы обрабатываем отдельно
+function isInterviewPath(filePath) {
+  return filePath.startsWith('interviews/')
+}
+
+function isArticleIndex(filePath) {
+  return (
+    /(^|\/)index\.md$/.test(filePath) &&
+    !filePath.startsWith('docs/') &&
+    !isInterviewPath(filePath)
+  )
+}
+
+function isPracticeFile(filePath) {
+  return /\/practice\/[^/]+\.md$/.test(filePath)
+}
+
+function articleIndexFromPractice(filePath) {
+  // css/color/practice/foo.md → css/color/index.md
+  return path.join(path.dirname(path.dirname(filePath)), 'index.md')
+}
+
+function checkForwardLinks(filePath) {
+  const content = readFile(filePath)
+  if (!content) {
+    return
+  }
+
+  const links = extractLinks(content)
+
+  for (const link of links) {
+    const url = normalizeDokaUrl(link.url)
+    if (shouldSkipUrl(url)) {
+      continue
+    }
+
+    const line = lineNumberAt(content, link.index)
+
+    if (!url.startsWith('/') && !url.startsWith('#')) {
+      const assetPath = resolveRelativeAsset(filePath, url)
+      if (!assetPath) {
+        continue
+      }
+
+      if (!checkAssetExists(assetPath)) {
+        fail(`${filePath}:${line} → не найден файл «${assetPath}» (ссылка ${link.raw})`)
+      }
+      continue
+    }
+
+    if (url.startsWith('#')) {
+      if (isInterviewPath(filePath)) {
+        continue
+      }
+      const anchors = extractArticleAnchors(
+        isPracticeFile(filePath) ? articleIndexFromPractice(filePath) : filePath
+      )
+      const hash = url.slice(1)
+      if (hash && !anchors.has(hash)) {
+        fail(`${filePath}:${line} → якорь #${hash} не найден в текущем материале`)
+      }
+      continue
+    }
+
+    const { pathname, hash } = splitUrl(url)
+    const targetFile = resolveArticleFile(pathname)
+
+    if (!targetFile) {
+      fail(`${filePath}:${line} → нет материала по пути «${pathname}» (ссылка ${link.raw})`)
+      continue
+    }
+
+    // до раздела интервью добрались только по существованию файла:
+    // якоря там формируются не из ## заголовков, проверять их нечем
+    if (!hash || isInterviewPath(targetFile)) {
+      continue
+    }
+
+    const anchors = extractArticleAnchors(targetFile)
+    if (!anchors.has(hash)) {
+      fail(
+        `${filePath}:${line} → в «${targetFile}» нет якоря #${hash} (ссылка ${link.raw})`
+      )
+    }
+  }
+}
+
+function shellQuote(value) {
+  return `'${String(value).replace(/'/g, `'\\''`)}'`
+}
+
+// общий раннер для git-подкоманд: аргументы всегда экранируются через
+// shellQuote, а обработка «ожидаемых» ошибок (нет объекта, нет совпадений)
+// отдаётся вызывающей стороне через onError
+function runGit(gitArgs, { onError } = {}) {
+  const command = `git ${gitArgs.map(shellQuote).join(' ')}`
+  try {
+    return execSync(command, {
+      encoding: 'utf8',
+      maxBuffer: 10 * 1024 * 1024,
+      stdio: ['pipe', 'pipe', 'pipe'],
+    })
+  } catch (error) {
+    if (onError) {
+      return onError(error)
+    }
+    throw error
+  }
+}
+
+function gitGrepFixed(pattern) {
+  const output = runGit(['grep', '-n', '-F', '-e', pattern, '--', '*.md'], {
+    onError: (error) => {
+      if (error.status === 1) {
+        return ''
+      }
+      throw error
+    },
+  })
+  return output.trim().split('\n').filter(Boolean)
+}
+
+function parseGitGrepLine(line) {
+  const match = line.match(/^([^:]+):(\d+):(.*)$/)
+  if (!match) {
+    return null
+  }
+  return {
+    filePath: match[1],
+    line: Number(match[2]),
+    text: match[3],
+  }
+}
+
+function escapeRegExp(value) {
+  return value.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')
+}
+
+// git grep -F ищет подстроку, поэтому «/js/closures» матчит «/js/closures-guide»,
+// а «#zamykanie» — «#zamykanie-2». Проверяем, что за паттерном нет символа,
+// который продолжал бы slug (буква, цифра или дефис)
+function hasBoundaryMatch(text, pattern) {
+  const regex = new RegExp(`${escapeRegExp(pattern)}(?![a-z0-9-])`)
+  return regex.test(text)
+}
+
+function checkReverseAnchors(articleIndexPath, removedAnchors) {
+  if (removedAnchors.size === 0) {
+    return
+  }
+
+  const pathname = articlePathnameFromFile(articleIndexPath)
+  const pathnameNoSlash = pathname.replace(/\/$/, '')
+
+  for (const anchor of removedAnchors) {
+    const patterns = [
+      `${pathname}#${anchor}`,
+      `${pathnameNoSlash}#${anchor}`,
+      `https://doka.guide${pathname}#${anchor}`,
+      `https://doka.guide${pathnameNoSlash}#${anchor}`,
+    ]
+
+    for (const pattern of patterns) {
+      for (const line of gitGrepFixed(pattern)) {
+        const hit = parseGitGrepLine(line)
+        if (!hit || !hasBoundaryMatch(hit.text, pattern)) {
+          continue
+        }
+        fail(
+          `${hit.filePath}:${hit.line} → ссылка на удалённый якорь ${pattern} (якорь пропал из ${articleIndexPath})`
+        )
+      }
+    }
+  }
+}
+
+function checkReverseArticlePath(articleIndexPath) {
+  const pathname = articlePathnameFromFile(articleIndexPath)
+  const pathnameNoSlash = pathname.replace(/\/$/, '')
+  const patterns = [
+    pathname,
+    pathnameNoSlash,
+    `https://doka.guide${pathname}`,
+    `https://doka.guide${pathnameNoSlash}`,
+  ]
+
+  for (const pattern of patterns) {
+    for (const line of gitGrepFixed(pattern)) {
+      const hit = parseGitGrepLine(line)
+      if (!hit || hit.filePath === articleIndexPath) {
+        continue
+      }
+
+      if (!hasBoundaryMatch(hit.text, pattern)) {
+        continue
+      }
+
+      if (!/\]\([^)]*\)|href=["'][^"']*|https:\/\/doka\.guide|related:/i.test(hit.text)) {
+        continue
+      }
+
+      fail(
+        `${hit.filePath}:${hit.line} → ссылка на удалённый материал ${pattern} (удалён ${articleIndexPath})`
+      )
+    }
+  }
+}
+
+function unique(files) {
+  return [...new Set(files.filter(Boolean))]
+}
+
+function main() {
+  const markdownFiles = unique(
+    changedFiles.filter((file) => file.endsWith('.md'))
+  )
+
+  if (markdownFiles.length === 0) {
+    console.log('Нет изменённых Markdown-файлов для проверки ссылок')
+    return
+  }
+
+  console.log(`Проверяю ссылки в ${markdownFiles.length} файлах…`)
+
+  for (const filePath of markdownFiles) {
+    if (readFile(filePath)) {
+      checkForwardLinks(filePath)
+    }
+  }
+
+  const articlePaths = new Set()
+
+  for (const filePath of markdownFiles) {
+    if (isArticleIndex(filePath)) {
+      articlePaths.add(filePath)
+    } else if (isPracticeFile(filePath)) {
+      articlePaths.add(articleIndexFromPractice(filePath))
+    }
+  }
+
+  for (const articleIndexPath of articlePaths) {
+    const existsNow = readFile(articleIndexPath) !== null
+    const existedBefore = baseSha ? readFileAtBase(articleIndexPath) !== null : false
+
+    if (!existsNow && existedBefore) {
+      checkReverseArticlePath(articleIndexPath)
+      continue
+    }
+
+    if (!existsNow || !baseSha) {
+      continue
+    }
+
+    const oldAnchors = extractArticleAnchors(articleIndexPath, readFileAtBase)
+    const newAnchors = extractArticleAnchors(articleIndexPath, readFile)
+    const removedAnchors = new Set(
+      [...oldAnchors].filter((anchor) => !newAnchors.has(anchor))
+    )
+
+    if (removedAnchors.size > 0) {
+      console.log(
+        `В ${articleIndexPath} пропали якоря: ${[...removedAnchors].join(', ')}`
+      )
+      checkReverseAnchors(articleIndexPath, removedAnchors)
+    }
+  }
+
+  if (errors.size > 0) {
+    console.error(`\nНайдено ошибок: ${errors.size}`)
+    process.exit(1)
+  }
+
+  console.log('Битых внутренних ссылок не найдено')
+}
+
+main()

--- a/.github/scripts/link-check.js
+++ b/.github/scripts/link-check.js
@@ -318,7 +318,7 @@ function resolveArticleFile(pathname) {
 
   const [section] = parts
   if (!SECTION_ROOTS.has(section)) {
-    return PLATFORM_ROUTE
+    return null
   }
 
   if (parts.length === 1) {

--- a/.github/scripts/link-check.test.js
+++ b/.github/scripts/link-check.test.js
@@ -1,0 +1,274 @@
+// node --test .github/scripts/link-check.test.js
+const test = require('node:test')
+const assert = require('node:assert/strict')
+const fs = require('node:fs')
+const path = require('node:path')
+const os = require('node:os')
+const { execFileSync } = require('node:child_process')
+
+const SCRIPT = path.join(__dirname, 'link-check.js')
+
+// создаёт временный репозиторий-фикстуру: { 'css/color/index.md': '...' } → файлы на диске
+function makeRepo(files) {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'link-check-'))
+  writeFiles(dir, files)
+  return dir
+}
+
+function writeFiles(dir, files) {
+  for (const [relPath, content] of Object.entries(files)) {
+    const absolutePath = path.join(dir, relPath)
+    fs.mkdirSync(path.dirname(absolutePath), { recursive: true })
+    fs.writeFileSync(absolutePath, content)
+  }
+}
+
+function removeFile(dir, relPath) {
+  fs.rmSync(path.join(dir, relPath))
+}
+
+function git(dir, args) {
+  return execFileSync('git', args, { cwd: dir, encoding: 'utf8' })
+}
+
+function gitInit(dir) {
+  git(dir, ['init', '-q'])
+  git(dir, ['config', 'user.email', 'test@test.com'])
+  git(dir, ['config', 'user.name', 'Test'])
+}
+
+function gitCommitAll(dir, message) {
+  git(dir, ['add', '-A'])
+  git(dir, ['commit', '-q', '-m', message])
+  return git(dir, ['rev-parse', 'HEAD']).trim()
+}
+
+// прогоняет link-check.js как реальный CLI-процесс — так же, как его вызывает workflow
+function runCheck(dir, changedFiles, env = {}) {
+  try {
+    const output = execFileSync('node', [SCRIPT, ...changedFiles], {
+      cwd: dir,
+      encoding: 'utf8',
+      env: { ...process.env, ...env },
+    })
+    return { code: 0, output }
+  } catch (error) {
+    return {
+      code: typeof error.status === 'number' ? error.status : 1,
+      output: `${error.stdout || ''}${error.stderr || ''}`,
+    }
+  }
+}
+
+const FRONTMATTER = 'title: test\n'
+
+function article(body) {
+  return `---\n${FRONTMATTER}---\n\n${body}\n`
+}
+
+test('валидная ссылка на существующую статью проходит', () => {
+  const dir = makeRepo({
+    'css/color/index.md': article('## Кратко\n\nПро цвет.'),
+    'css/border/index.md': article('Смотри [цвет](/css/color/).'),
+  })
+
+  const { code, output } = runCheck(dir, ['css/border/index.md'])
+
+  assert.equal(code, 0, output)
+  assert.match(output, /Битых внутренних ссылок не найдено/)
+})
+
+test('ссылка на несуществующую статью падает', () => {
+  const dir = makeRepo({
+    'css/border/index.md': article('Смотри [битую ссылку](/css/no-such-thing/).'),
+  })
+
+  const { code, output } = runCheck(dir, ['css/border/index.md'])
+
+  assert.equal(code, 1)
+  assert.match(output, /нет материала по пути «\/css\/no-such-thing\/»/)
+})
+
+test('регрессия: опечатка в названии раздела и выдуманный раздел всё ещё считаются битыми', () => {
+  // PLATFORM_ROUTE изначально задумывался только для конкретных платформенных
+  // роутов (/, /people/, /subscribe/), но фикс сначала случайно применил его
+  // как fallback для ЛЮБОГО нераспознанного первого сегмента пути — это
+  // тихо гасило все ссылки с опечаткой в разделе
+  const dir = makeRepo({
+    'css/border/index.md': article(
+      'Ссылки: [опечатка](/hmtl/div/) и [выдумка](/totally-made-up-section/here/).'
+    ),
+  })
+
+  const { code, output } = runCheck(dir, ['css/border/index.md'])
+
+  assert.equal(code, 1)
+  assert.match(output, /нет материала по пути «\/hmtl\/div\/»/)
+  assert.match(output, /нет материала по пути «\/totally-made-up-section\/here\/»/)
+})
+
+test('платформенные роуты (/, /people/, /subscribe/) не считаются битыми', () => {
+  const dir = makeRepo({
+    'pages/newsletters/index.md': article(
+      '[Рассылка](/subscribe/), [сообщество](/people/) и [главная](https://doka.guide/).'
+    ),
+  })
+
+  const { code, output } = runCheck(dir, ['pages/newsletters/index.md'])
+
+  assert.equal(code, 0, output)
+})
+
+test('демка с query-строкой ?embed=1 резолвится с учётом реального файла', () => {
+  const dir = makeRepo({
+    'css/color/index.md': article(
+      '```css\n.a { color: red; }\n```\n\n<iframe src="demos/example/?embed=1"></iframe>'
+    ),
+    'css/color/demos/example/index.html': '<html></html>',
+  })
+
+  const okRun = runCheck(dir, ['css/color/index.md'])
+  assert.equal(okRun.code, 0, okRun.output)
+
+  // без реальной директории ошибка должна остаться — фикс не должен отключать проверку целиком
+  // (fs.existsSync истинен и для директории, поэтому удаляем её целиком, а не файл внутри)
+  fs.rmSync(path.join(dir, 'css/color/demos/example'), { recursive: true })
+  const failRun = runCheck(dir, ['css/color/index.md'])
+  assert.equal(failRun.code, 1)
+  assert.match(failRun.output, /не найден файл/)
+})
+
+test('заголовок-название тега в бэктиках (### `<td>`) даёт рабочий якорь', () => {
+  const dir = makeRepo({
+    'html/tables/index.md': article('## Структурные теги\n\n### `<td>`\n\nЯчейка таблицы.'),
+    'a11y/foo/index.md': article('Смотри [`<td>`](/html/tables/#td).'),
+  })
+
+  const { code, output } = runCheck(dir, ['a11y/foo/index.md'])
+
+  assert.equal(code, 0, output)
+})
+
+test('иллюстративный пример атрибута в инлайн-коде не принимается за ссылку', () => {
+  const dir = makeRepo({
+    'html/a/index.md': article(
+      'Атрибут `href="URL"` обязателен. Пример: `<a href="#chapter1">Глава 1</a>`.'
+    ),
+  })
+
+  const { code, output } = runCheck(dir, ['html/a/index.md'])
+
+  assert.equal(code, 0, output)
+})
+
+test('якорь хаб-страницы раздела (YAML groups[].name) резолвится', () => {
+  const dir = makeRepo({
+    'html/index.md':
+      "---\nname: 'HTML'\ngroups:\n  - name: 'Семантика'\n    items:\n      - div\n---\n",
+    'a11y/foo/index.md': article('Смотри [семантические теги](/html/#semantika).'),
+  })
+
+  const { code, output } = runCheck(dir, ['a11y/foo/index.md'])
+
+  assert.equal(code, 0, output)
+})
+
+test('legacy-якорь <a name="..."> резолвится', () => {
+  const dir = makeRepo({
+    'css/visited/index.md': article('<a name="limits"></a>\n\n## Ограничения\n\nТекст.'),
+    'css/other/index.md': article('Смотри [ограничения](/css/visited/#limits).'),
+  })
+
+  const { code, output } = runCheck(dir, ['css/other/index.md'])
+
+  assert.equal(code, 0, output)
+})
+
+test('markdown-ссылка в угловых скобках со скобками внутри URL не ломает проверку', () => {
+  const dir = makeRepo({
+    'js/foo/index.md': article(
+      'Подробнее: [wiki](<https://ru.wikipedia.org/wiki/Test_(значение)>).'
+    ),
+  })
+
+  const { code, output } = runCheck(dir, ['js/foo/index.md'])
+
+  assert.equal(code, 0, output)
+})
+
+test('якорь, отсутствующий в целевой статье, считается битым', () => {
+  const dir = makeRepo({
+    'css/color/index.md': article('## Кратко\n\nПро цвет.'),
+    'css/border/index.md': article('Смотри [цвет](/css/color/#no-such-anchor).'),
+  })
+
+  const { code, output } = runCheck(dir, ['css/border/index.md'])
+
+  assert.equal(code, 1)
+  assert.match(output, /нет якоря #no-such-anchor/)
+})
+
+test('авто-якоря блока «На практике» резолвятся', () => {
+  const dir = makeRepo({
+    'css/color/index.md': article('## Кратко\n\nПро цвет.'),
+    'css/color/practice/solarrust.md': '🛠 Совет на практике.\n',
+    'people/solarrust/index.md': "---\nname: 'Алёна Батицкая'\n---\n",
+    'css/other/index.md': article(
+      'Смотри [на практике](/css/color/#na-praktike) и [совет Алёны](/css/color/#practices-solarrust).'
+    ),
+  })
+
+  const { code, output } = runCheck(dir, ['css/other/index.md'])
+
+  assert.equal(code, 0, output)
+})
+
+test('якорь #na-sobesedovanii резолвится через related: в interviews', () => {
+  const dir = makeRepo({
+    'tools/fp/index.md': article('## Кратко\n\nПро ФП.'),
+    'interviews/some-question/index.md': "---\nrelated:\n  - tools/fp\n---\n",
+    'specials/pfc/index.md': article('Смотри [вопрос на собеседовании](/tools/fp/#na-sobesedovanii).'),
+  })
+
+  const { code, output } = runCheck(dir, ['specials/pfc/index.md'])
+
+  assert.equal(code, 0, output)
+})
+
+test('reverse-check: ссылка на удалённый якорь в другом файле ловится через BASE_SHA', () => {
+  const dir = makeRepo({
+    'css/color/index.md': article('## Ограничения\n\nТекст.'),
+    'css/other/index.md': article('Смотри [ограничения](/css/color/#ogranicheniya).'),
+  })
+  gitInit(dir)
+  const baseSha = gitCommitAll(dir, 'init')
+
+  // в рабочей копии заголовок переименован — якорь #ogranicheniya пропал,
+  // но css/other/index.md на него всё ещё ссылается
+  writeFiles(dir, {
+    'css/color/index.md': article('## Что-то другое\n\nТекст.'),
+  })
+
+  const { code, output } = runCheck(dir, ['css/color/index.md'], { BASE_SHA: baseSha })
+
+  assert.equal(code, 1)
+  assert.match(output, /ссылка на удалённый якорь/)
+  assert.match(output, /css\/other\/index\.md/)
+})
+
+test('reverse-check: ссылка на удалённую статью ловится через BASE_SHA', () => {
+  const dir = makeRepo({
+    'css/color/index.md': article('## Кратко\n\nПро цвет.'),
+    'css/other/index.md': article('Смотри [цвет](/css/color/).'),
+  })
+  gitInit(dir)
+  const baseSha = gitCommitAll(dir, 'init')
+
+  removeFile(dir, 'css/color/index.md')
+
+  const { code, output } = runCheck(dir, ['css/color/index.md'], { BASE_SHA: baseSha })
+
+  assert.equal(code, 1)
+  assert.match(output, /ссылка на удалённый материал/)
+  assert.match(output, /css\/other\/index\.md/)
+})

--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -63,17 +63,23 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
       - id: files
         if: ${{ github.event_name == 'pull_request' }}
         uses: Ana06/get-changed-files@v2.2.0
         with:
           filter: '*.md'
-          format: 'csv'
+          format: 'space-delimited'
       - name: Проверяет ссылки
-        if: ${{ steps.files.outputs.added_modified != '' }}
-        uses: JustinBeckwith/linkinator-action@v1
-        with:
-          paths: ${{ steps.files.outputs.added_modified }}
-          markdown: true
-          serverRoot: "/home/runner/work/content/content"
-          linksToSkip: "https?://(localhost|codepen.io)?(:[0-9]+)?/.*"
+        if: ${{ steps.files.outputs.added_modified != '' || steps.files.outputs.removed != '' }}
+        run: |
+          npm install transliteration --no-save
+          node .github/scripts/link-check.js \
+            ${{ steps.files.outputs.added_modified }} \
+            ${{ steps.files.outputs.removed }}
+        env:
+          BASE_SHA: ${{ github.event.pull_request.base.sha }}


### PR DESCRIPTION
## Описание

Заменяет проверку ссылок в PR с `linkinator-action` на собственный чекер внутренних ссылок.

Старый чекер скипал локальный сервер `linkinator` и в PR фактически сканировал `0` ссылок. Из-за этого битые внутренние ссылки находились только еженедельной проверкой по живому сайту.

## Что изменилось

- Добавлен `.github/scripts/link-check.js`.
- В `pr-checks.yml` job «Ссылки» теперь запускает свой скрипт вместо `JustinBeckwith/linkinator-action`.
- Проверяются только изменённые в PR `.md`-файлы.
- Проверяются внутренние ссылки:
  - существование целевого материала;
  - существование якоря в целевом материале;
  - относительные ссылки на файлы, картинки и демки.
- Если в изменённом материале пропал заголовок, чекер ищет по репозиторию ссылки на удалённый якорь и валит PR.

## Как проверяет

- `/css/color/` → есть ли `css/color/index.md`;
- `/css/color/#kak-ponyat` → есть ли якорь `kak-ponyat`;
- `images/example.png`, `demos/example/`, `../demos/example/` → есть ли файл или папка;
- `https://doka.guide/...` обрабатывается как внутренняя ссылка;
- внешние `https://...`, `mailto:` и `tel:` пропускаются.

Slug якорей считается через `transliteration`, как на платформе в `headings-id-transform.js`.

## Что не проверяется

- Внешние ссылки остаются в еженедельной проверке `link-checker-all.yml`.
- `related` не дублируется, потому что уже проверяется в job «Мета».
- Якоря внутри `interviews/**` не проверяются, потому что в этом разделе id генерируются иначе.

## Проверка

- Сломанный внутренний якорь → ошибка с номером строки.
- Переименование заголовка → находятся ссылки на удалённый якорь.
- Битый внутренний путь → ошибка.
- Корректные ссылки → зелёный чек.