### PR TITLE
Исправляет блокировку чекаута PR из форков в CI-воркфлоу

### DIFF
--- a/.github/workflows/pr-labels.yml
+++ b/.github/workflows/pr-labels.yml
@@ -11,6 +11,7 @@ jobs:
       - uses: actions/checkout@v4
         with:
           ref: ${{ github.event.pull_request.head.sha }}
+          allow-unsafe-pr-checkout: true
       - name: Устанавливает необходимые ярлыки
         uses: doka-guide/doka-labeler@v1.0.1
         with:

--- a/.github/workflows/pr-preview.yml
+++ b/.github/workflows/pr-preview.yml
@@ -40,6 +40,7 @@ jobs:
         with:
           ref: ${{ github.event.pull_request.head.sha }}
           path: content
+          allow-unsafe-pr-checkout: true
       - name: Загрузка кеша
         uses: actions/checkout@v4
         with:


### PR DESCRIPTION
## Причина

GitHub Actions недавно начал блокировать чекаут кода PR из форков внутри `pull_request_target`-воркфлоу без явного опт-ина — это защита от pwn request (форк-код в контексте с доступом к секретам base-репозитория).

Из-за этого на всех PR от внешних авторов падали:
- **«Сборка и загрузка превью»** (`pr-preview.yml`) — чекаутит контент PR для сборки превью-сайта
- **«Ярлыки»** (`pr-labels.yml`) — чекаутит контент PR, чтобы прочитать front matter изменённых файлов для расстановки лейблов

Оба джоба закономерно нуждаются в реальном содержимом PR (не только в base-ветке), поэтому просто убрать чекаут форка нельзя.

## Правка

Добавлен `allow-unsafe-pr-checkout: true` на оба шага `actions/checkout@v4`, которые чекаутят `github.event.pull_request.head.sha`. Это восстанавливает поведение, которое и так уже использовалось (секреты в `pull_request_target` для контента из форков применялись и раньше — до появления этого гейта в Actions).

## Test plan

- [ ] Проверить, что джобы «Сборка и загрузка превью» и «Ярлыки» проходят на этом PR