### PR TITLE
Правит рейт-лимит `editorconfig-checker` в CI-воркфлоу

### DIFF
--- a/.github/workflows/editorconfig.yml
+++ b/.github/workflows/editorconfig.yml
@@ -16,6 +16,8 @@ jobs:
       - id: files
         uses: Ana06/get-changed-files@v2.3.0
       - name: Проверка линтером
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           npm install editorconfig-checker --global
           config=.editorconfig

--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -16,6 +16,8 @@ jobs:
         if: ${{ github.event_name == 'pull_request' }}
         uses: Ana06/get-changed-files@v2.2.0
       - name: Работает линтер
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           npm install editorconfig-checker --global
           config=.editorconfig


### PR DESCRIPTION
## Причина

`EditorConfig` в CI иногда падал с `403 rate limit exceeded` при установке `editorconfig-checker`: пакет скачивает бинарник с `api.github.com/repos/editorconfig-checker/editorconfig-checker/releases/latest` без авторизации, а такие запросы делятся общим лимитом 60/час на IP раннера — он общий для всех джобов GitHub Actions на этом хосте.

Проблема была в двух местах:
- `editorconfig.yml` — проверка при пуше в `main`
- `pr-checks.yml` — проверка в PR

## Правка

Пробросила `GITHUB_TOKEN` в env шага в обоих воркфлоу — пакет использует Octokit с `auth: process.env.GITHUB_TOKEN`, поэтому запрос становится аутентифицированным и лимит поднимается до 5000/час.

## Test plan

- [ ] Проверить, что джоб «Проверка линтером» проходит в этом PR и после мёрджа в `main`