### PR TITLE
Берёт версию Node из .nvmrc платформы

### DIFF
--- a/.github/workflows/pr-preview.yml
+++ b/.github/workflows/pr-preview.yml
@@ -46,9 +46,13 @@ jobs:
         with:
           repository: doka-guide/cache
           path: cache
+      # Версия берётся из .nvmrc платформы: именно её зависимости здесь
+      # ставятся. Зашитая версия разъезжается с платформой — так превью и
+      # выкатка сломались, когда платформа перешла на Node 24, а здесь
+      # осталась двадцатая.
       - uses: actions/setup-node@v4
         with:
-          node-version: 20
+          node-version-file: .nvmrc
       - name: Кэширование модулей
         uses: actions/cache@v3
         env:

--- a/.github/workflows/product-deploy.yml
+++ b/.github/workflows/product-deploy.yml
@@ -29,9 +29,13 @@ jobs:
         with:
           repository: doka-guide/cache
           path: cache
+      # Версия берётся из .nvmrc платформы: именно её зависимости здесь
+      # ставятся. Зашитая версия разъезжается с платформой — так превью и
+      # выкатка сломались, когда платформа перешла на Node 24, а здесь
+      # осталась двадцатая.
       - uses: actions/setup-node@v4
         with:
-          node-version: 20
+          node-version-file: .nvmrc
       - name: Кэширование модулей
         uses: actions/cache@v3
         env:


### PR DESCRIPTION
## Что сломалось

Превью и боевая выкатка контента собирают сайт **платформой**, то есть ставят её зависимости. Но версия Node была зашита здесь числом — `node-version: 20`. Платформа тем временем перешла на Node 24, и сборка начала падать:

```
npm error code EBADENGINE
npm error Not compatible with your version of node/npm: @asamuzakjp/css-color@6.0.7
npm error notsup Required: {"node":"^22.13.0 || >=24.0.0"}
npm error notsup Actual:   {"npm":"10.8.2","node":"v20.20.2"}
```

Ошибка фатальная, а не предупреждение, потому что в `.npmrc` платформы стоит `engine-strict = true`.

Видно на [#6110](https://github.com/doka-guide/content/pull/6110): «Сборка и загрузка превью» падает через 21 секунду, на шаге установки модулей.

## Почему это срочно

Та же зашитая версия стоит и в `product-deploy.yml`. Последняя боевая выкатка контента была **21 августа**, а платформа обновилась 27-го — то есть **следующий же мерж в `main` сломает выкатку сайта**, а не только превью.

## Починка

```yaml
- uses: actions/setup-node@v4
  with:
    node-version-file: .nvmrc
```

Платформа чекаутится в корень, поэтому её `.nvmrc` лежит рядом. Версия перестаёт быть зашитой в двух местах и всегда следует за платформой: обновится там — поедет и здесь. Ровно так это устроено в самой платформе с #1349.

## Что не тронуто

Остальные десять мест с `node-version: 20` оставлены как есть: они запускают инструменты самого контента и зависимости платформы не ставят. Проверено — платформу чекаутят только `pr-preview.yml` и `product-deploy.yml`.

## Как проверить

После мержа перезапустить превью на #6110 — оно должно позеленеть.