### PR TITLE
Чинит превью контента: сборку, сообщения бота и пустой коммит

### DIFF
--- a/.github/workflows/pr-preview.yml
+++ b/.github/workflows/pr-preview.yml
@@ -120,7 +120,7 @@ jobs:
           repository: ${{ github.repository }}
           number: ${{ github.event.pull_request.number }}
           id: preview-${{ github.event.pull_request.number }}
-          message: "Превью контента из ${{ github.event.after }} не опубликовано. Ошибка сборки или публикации. [Подробнее](https://github.com/${{ github.repository }}/runs/${{ steps.check.outputs.check_id }}?check_suite_focus=true)"
+          message: "Превью контента из ${{ github.event.pull_request.head.sha }} не опубликовано. Ошибка сборки или публикации. [Подробнее](https://github.com/${{ github.repository }}/runs/${{ steps.check.outputs.check_id }}?check_suite_focus=true)"
           fail: true
           recreate: true
       - name: Сообщение об успехе публикации превью
@@ -131,5 +131,5 @@ jobs:
           repository: ${{ github.repository }}
           number: ${{ github.event.pull_request.number }}
           id: preview-${{ github.event.pull_request.number }}
-          message: '<details><summary><a href="${{ env.DEPLOY_DOMAIN }}">Превью контента</a> из ${{ github.event.after }} опубликовано.</summary>${{ steps.links.outputs.list }}</details>'
+          message: '<details><summary><a href="${{ env.DEPLOY_DOMAIN }}">Превью контента</a> из ${{ github.event.pull_request.head.sha }} опубликовано.</summary>${{ steps.links.outputs.list }}</details>'
           recreate: true

--- a/.github/workflows/pr-preview.yml
+++ b/.github/workflows/pr-preview.yml
@@ -107,14 +107,17 @@ jobs:
         continue-on-error: true
         run: |
           cp .env.example .env
-          npm run preview
+          npm run build
           ssh -i $HOME/.ssh/doka_deploy -o StrictHostKeyChecking=no deploy@dev.doka.guide mkdir -p /web/sites/dev.doka.guide/content/${{ github.event.pull_request.number }}
           cd dist && rsync -e "ssh -i $HOME/.ssh/doka_deploy -o StrictHostKeyChecking=no" --archive --progress --compress --delete . deploy@dev.doka.guide:/web/sites/dev.doka.guide/content/${{ github.event.pull_request.number }}
           echo "Ссылка на превью — ${{ env.DEPLOY_DOMAIN }}"
           echo -e "${{ steps.links.outputs.list }}"
+      # Шаг сборки помечен continue-on-error, поэтому его падение не делает
+      # джобу упавшей: if: failure() тут не срабатывает, а if: success()
+      # срабатывает всегда. Смотрим на исход самого шага.
       - name: Сообщение о неудаче публикации превью
         uses: hasura/comment-progress@v2.1.0
-        if: failure()
+        if: steps.build-preview.outcome == 'failure'
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           repository: ${{ github.repository }}
@@ -125,7 +128,7 @@ jobs:
           recreate: true
       - name: Сообщение об успехе публикации превью
         uses: hasura/comment-progress@v2.1.0
-        if: success()
+        if: steps.build-preview.outcome == 'success'
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           repository: ${{ github.repository }}


### PR DESCRIPTION
Три бага в `pr-preview.yml`, найденные при разборе того, почему превью на [#6110](https://github.com/doka-guide/content/pull/6110) сначала падало, а потом стало зеленеть за 38 секунд вместо семи минут.

## 1. Превью зеленело, ничего не собрав

Шаг сборки вызывает `npm run preview`, но такого скрипта в платформе нет — его убрали в [platform#1349](https://github.com/doka-guide/platform/pull/1349):

```
npm run preview
npm error Missing script: "preview"
```

Команда падает мгновенно. Заменено на `npm run build`.

## 2. Падение сборки не приводило к красной проверке

Шаг помечен `continue-on-error: true`, поэтому его падение **не делает джобу упавшей**. Отсюда два следствия:

- `if: failure()` у сообщения о неудаче **никогда не срабатывает**
- `if: success()` у сообщения об успехе **срабатывает всегда**

То есть бот сообщал об опубликованном превью, которого нет, а проверка стояла зелёной. Именно так выглядел прогон на #6110: все шаги «успешны», сборка заняла 0 секунд.

Теперь оба сообщения смотрят на исход самого шага — `steps.build-preview.outcome`.

## 3. Пустой коммит в сообщении бота

> Превью контента из  не опубликовано.

В шаблоне стоял `${{ github.event.after }}` — поле события **push**, которого нет в полезной нагрузке `pull_request_target`. Заменено на `${{ github.event.pull_request.head.sha }}` — то самое поле, которым этот же воркфлоу забирает коммит для чекаута.

## Почему всё это всплыло только сейчас

Первые два бага появились вместе с [platform#1349](https://github.com/doka-guide/platform/pull/1349), но были не видны: джоба падала раньше, на установке модулей, из-за расхождения версий Node. Как только это починили в #6113, проявилась настоящая поломка — уже в виде ложно-зелёной проверки.