### PR TITLE
Убирает кеш модулей из сборки превью

### DIFF
--- a/.github/workflows/pr-preview.yml
+++ b/.github/workflows/pr-preview.yml
@@ -137,17 +137,6 @@ jobs:
       - uses: actions/setup-node@v4
         with:
           node-version-file: .nvmrc
-      - name: Кэширование модулей
-        uses: actions/cache@v3
-        env:
-          cache-name: cache-node-modules
-        with:
-          path: ~/.npm
-          key: ${{ runner.os }}-build-${{ env.cache-name }}-${{ hashFiles('**/package-lock.json') }}
-          restore-keys: |
-            ${{ runner.os }}-build-${{ env.cache-name }}-
-            ${{ runner.os }}-build-
-            ${{ runner.os }}-
       - name: Установка модулей
         run: npm ci
       - name: Копирование кеша


### PR DESCRIPTION
## Что происходит

В джобе превью на каждом прогоне падает шаг сохранения кеша:

```
Warning: Cache reservation failed: cache write denied: token has no writable scopes
Failed to save: Unable to reserve cache with key Linux-build-cache-node-modules-...
```

Причина — моя же правка: когда сводила превью в две джобы, объявила права явно, и записывать кеш джоба больше не может.

**Сборку это не ломает.** Превью собирается и публикуется как обычно, падает только сохранение кеша.

## Почему убираю, а не чиню правами

Кеш и не окупался. По цифрам последнего прогона:

| шаг | время |
|---|---|
| восстановление кеша | 1 с, ничего не нашёл |
| `npm ci` | 15 с |
| сборка и публикация | 367 с |

То есть в лучшем случае он экономил бы секунд семь из шести с половиной минут.

Чтобы вернуть, пришлось бы дать джобе `actions: write`. А в ней выполняется код из форка — с таким правом он может подложить в кеш что угодно для следующих прогонов. Ради семи секунд это плохой размен.

Такой же шаг есть в `product-deploy.yml`, но там права по умолчанию и предупреждения нет — его не трогаю.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- doka-preview-6120 -->
<a href="https://content-6120.dev.doka.guide">Превью контента</a> из 1a23755058895fd86d39dcdb53a0907b9ebffd69 опубликовано.
<!-- /doka-preview-6120 -->