### PR TITLE
Убирает несуществующие материалы из related статьи про :dir()

### DIFF
--- a/css/dir/index.md
+++ b/css/dir/index.md
@@ -15,8 +15,6 @@ keywords:
   - направление письма
 related:
   - html/bdo
-  - css/direction
-  - css/any-link
 tags:
   - doka
 ---


### PR DESCRIPTION
Фронтматтер-линтер упал на main после мержа #6023: related ссылался на `css/direction` (такой статьи никогда не было) и `css/any-link` (существует только в открытом #6021, ещё не смержен). Убрал обе записи — `css/any-link` можно будет вернуть, когда #6021 смержится.

<!-- doka-preview-6128 -->
<a href="https://content-6128.dev.doka.guide">Превью контента</a> из 01f64c0de0b2a726c5b116a1756a3987e9b3dc09 опубликовано.<details><summary>Затронутые материалы</summary><ul><li><a href="https://content-6128.dev.doka.guide/css/dir/">/css/dir/</a></li></ul></details>
<!-- /doka-preview-6128 -->