### PR TITLE
Дополняет словарь орфографии термином CIELAB

### DIFF
--- a/.yaspeller.json
+++ b/.yaspeller.json
@@ -783,6 +783,7 @@
     "SVGOMG",
     "TTFB",
     "WCAG",
-    "yaspeller"
+    "yaspeller",
+    "CIELAB"
   ]
 }


### PR DESCRIPTION
Использовано в уточнённом alt-тексте картинки oklabch.png в статье про цвета.

<!-- doka-preview-6129 -->
<a href="https://content-6129.dev.doka.guide">Превью контента</a> из b9adb0aacb8a0f2e61322ac8a48c4f5685bb0455 опубликовано.
<!-- /doka-preview-6129 -->