### PR TITLE
Возвращает стили и анимацию светофора в демке про сигналы

### DIFF
--- a/tools/signals/demos/diamond/index.html
+++ b/tools/signals/demos/diamond/index.html
@@ -54,33 +54,33 @@
       padding: 8px;
       background-color: #0e0f11;
       border-radius: 14px;
+    }
 
-      &-bulb {
-        width: 18px;
-        height: 18px;
-        border-radius: 50%;
-        opacity: 0.25;
-        transition: opacity 0.15s ease;
+    .demo__light-bulb {
+      width: 18px;
+      height: 18px;
+      border-radius: 50%;
+      opacity: 0.25;
+      transition: opacity 0.15s ease;
+    }
 
-        &--red { background-color: #ff6b6b; }
-        &--yellow { background-color: #ffd166; }
-        &--green { background-color: #6ee7b7; }
-      }
+    .demo__light-bulb--red { background-color: #ff6b6b; }
+    .demo__light-bulb--yellow { background-color: #ffd166; }
+    .demo__light-bulb--green { background-color: #6ee7b7; }
 
-      &[data-state="red"] .demo__light-bulb--red {
-        opacity: 1;
-        box-shadow: 0 0 14px 2px #ff6b6b;
-      }
+    .demo__light[data-state="red"] .demo__light-bulb--red {
+      opacity: 1;
+      box-shadow: 0 0 14px 2px #ff6b6b;
+    }
 
-      &[data-state="yellow"] .demo__light-bulb--yellow {
-        opacity: 1;
-        box-shadow: 0 0 14px 2px #ffd166;
-      }
+    .demo__light[data-state="yellow"] .demo__light-bulb--yellow {
+      opacity: 1;
+      box-shadow: 0 0 14px 2px #ffd166;
+    }
 
-      &[data-state="green"] .demo__light-bulb--green {
-        opacity: 1;
-        box-shadow: 0 0 14px 2px #6ee7b7;
-      }
+    .demo__light[data-state="green"] .demo__light-bulb--green {
+      opacity: 1;
+      box-shadow: 0 0 14px 2px #6ee7b7;
     }
 
     .demo__switch {
@@ -101,15 +101,15 @@
       color: #18191c;
       background-color: #ffd166;
       transition: transform 0.15s ease;
+    }
 
-      &:hover:not(:disabled) {
-        transform: translateY(-50%) scale(1.06);
-      }
+    .demo__switch:hover:not(:disabled) {
+      transform: translateY(-50%) scale(1.06);
+    }
 
-      &:disabled {
-        opacity: 0.6;
-        cursor: default;
-      }
+    .demo__switch:disabled {
+      opacity: 0.6;
+      cursor: default;
     }
 
     .demo__columns {
@@ -125,47 +125,47 @@
       display: flex;
       flex-direction: column;
       gap: 10px;
+    }
 
-      &-title {
-        font-size: 15px;
-        font-weight: 500;
-        color: #a9abb3;
-      }
+    .demo__panel-title {
+      font-size: 15px;
+      font-weight: 500;
+      color: #a9abb3;
     }
 
     .demo__row {
       display: flex;
       flex-direction: column;
       gap: 4px;
-
-      &-label {
-        font-size: 12px;
-        color: #a9abb3;
-      }
-
-      &-value {
-        overflow-wrap: anywhere;
-        font-variant-numeric: tabular-nums;
-        font-size: 15px;
-        font-weight: 500;
-        color: #ffffff;
-      }
-
-      &--recalcs {
-        align-items: center;
-        margin-top: 2px;
-        padding-top: 10px;
-        border-top: 1px solid #33343a;
-
-        .demo__row-value {
-          font-size: 26px;
-          color: #c4b5fd;
-
-          &--worse { color: #ff6b6b; }
-          &--better { color: #6ee7b7; }
-        }
-      }
     }
+
+    .demo__row-label {
+      font-size: 12px;
+      color: #a9abb3;
+    }
+
+    .demo__row-value {
+      overflow-wrap: anywhere;
+      font-variant-numeric: tabular-nums;
+      font-size: 15px;
+      font-weight: 500;
+      color: #ffffff;
+    }
+
+    .demo__row--recalcs {
+      align-items: center;
+      margin-top: 2px;
+      padding-top: 10px;
+      border-top: 1px solid #33343a;
+    }
+
+    .demo__row--recalcs .demo__row-value {
+      font-size: 26px;
+      color: #c4b5fd;
+    }
+
+    .demo__row-value--worse { color: #ff6b6b; }
+    .demo__row-value--better { color: #6ee7b7; }
 
     @media (max-width: 480px) {
       .demo__columns {


### PR DESCRIPTION
## Summary
- В демке светофора из статьи про сигналы вложенный CSS (`&-bulb`, `&--red`) ломал сборку платформы (postcss-csso), из-за этого пропадали лампочки и ехала вёрстка.
- Селекторы развёрнуты в обычный CSS, BEM-классы сохранены — анимация переключения снова работает.

Превью: https://content-6130.dev.doka.guide/tools/signals/

## Test plan
- [x] Открыть демку `tools/signals/demos/diamond/` на предпросмотре
- [x] Светофор виден: красный горит, жёлтый и зелёный приглушены
- [x] Кнопка переключения меняет цвет лампочки с анимацией opacity
- [x] Карточки «Наивный pub/sub» и «Сигналы» на месте, счётчики пересчётов окрашиваются


Made with [Cursor](https://cursor.com)

<!-- doka-preview-6130 -->
<a href="https://content-6130.dev.doka.guide">Превью контента</a> из 5b7ca9744bc79ddb2e6588ea3ed50dc40f07d2d0 опубликовано.
<!-- /doka-preview-6130 -->