### PR TITLE
Убирает лишние точки с запятой в демках

### DIFF
--- a/a11y/how-to-describe-pictures/demos/informative-img/index.html
+++ b/a11y/how-to-describe-pictures/demos/informative-img/index.html
@@ -40,7 +40,7 @@
     img {
       display: inline-block;
       width: 50%;
-      border: 2px solid #F498AD;;
+      border: 2px solid #F498AD;
     }
 
     @media (max-width: 768px) {

--- a/a11y/how-to-describe-pictures/demos/portrait-img/index.html
+++ b/a11y/how-to-describe-pictures/demos/portrait-img/index.html
@@ -40,7 +40,7 @@
     img {
       display: inline-block;
       width: 50%;
-      border: 2px solid #F498AD;;
+      border: 2px solid #F498AD;
     }
 
     @media (max-width: 768px) {

--- a/css/anchor-positioning-guide/demos/position-try-fallbacks/index.html
+++ b/css/anchor-positioning-guide/demos/position-try-fallbacks/index.html
@@ -39,7 +39,7 @@
 
     .anchor {
       anchor-name: --my-anchor;
-      background-color: #123E66;;
+      background-color: #123E66;
       padding: 20px 30px;
       font-size: 30px;
       place-content: center;

--- a/css/anchor-positioning-guide/demos/position-try-order/index.html
+++ b/css/anchor-positioning-guide/demos/position-try-order/index.html
@@ -39,7 +39,7 @@
 
     .anchor {
       anchor-name: --my-anchor;
-      background-color: #123E66;;
+      background-color: #123E66;
       text-align: center;
       padding: 40px 60px;
       width: auto;

--- a/css/anchor-positioning-guide/demos/position-try-rule/index.html
+++ b/css/anchor-positioning-guide/demos/position-try-rule/index.html
@@ -39,7 +39,7 @@
 
     .anchor {
       anchor-name: --my-anchor;
-      background-color: #123E66;;
+      background-color: #123E66;
       width: 230px;
       height: 110px;
       font-size: 30px;

--- a/css/anchor-positioning-guide/demos/position-visibility-anchors-visible/index.html
+++ b/css/anchor-positioning-guide/demos/position-visibility-anchors-visible/index.html
@@ -66,7 +66,7 @@
 
     .anchor {
       anchor-name: --anchor;
-      background-color: #123E66;;
+      background-color: #123E66;
       padding: 4px 8px;
       border-radius: 6px;
     }

--- a/css/position-try-fallbacks/demos/flip-block/index.html
+++ b/css/position-try-fallbacks/demos/flip-block/index.html
@@ -39,7 +39,7 @@
 
     .anchor {
       anchor-name: --my-anchor;
-      background-color: #123E66;;
+      background-color: #123E66;
       padding: 40px 70px;
       font-size: 30px;
       place-content: center;

--- a/css/position-try-fallbacks/demos/flip-inline/index.html
+++ b/css/position-try-fallbacks/demos/flip-inline/index.html
@@ -39,7 +39,7 @@
 
     .anchor {
       anchor-name: --my-anchor;
-      background-color: #123E66;;
+      background-color: #123E66;
       padding: 40px 70px;
       font-size: 30px;
       place-content: center;

--- a/css/position-try-fallbacks/demos/flip-start-1/index.html
+++ b/css/position-try-fallbacks/demos/flip-start-1/index.html
@@ -39,7 +39,7 @@
 
     .anchor {
       anchor-name: --my-anchor;
-      background-color: #123E66;;
+      background-color: #123E66;
       padding: 40px 70px;
       font-size: 30px;
       place-content: center;

--- a/css/position-try-fallbacks/demos/flip-start-2/index.html
+++ b/css/position-try-fallbacks/demos/flip-start-2/index.html
@@ -39,7 +39,7 @@
 
     .anchor {
       anchor-name: --my-anchor;
-      background-color: #123E66;;
+      background-color: #123E66;
       padding: 40px 70px;
       font-size: 30px;
       place-content: center;

--- a/css/position-try-fallbacks/demos/position-area/index.html
+++ b/css/position-try-fallbacks/demos/position-area/index.html
@@ -39,7 +39,7 @@
 
     .anchor {
       anchor-name: --my-anchor;
-      background-color: #123E66;;
+      background-color: #123E66;
       padding: 40px 70px;
       font-size: 30px;
       place-content: center;

--- a/css/position-try-fallbacks/demos/without-fallback/index.html
+++ b/css/position-try-fallbacks/demos/without-fallback/index.html
@@ -39,7 +39,7 @@
 
     .anchor {
       anchor-name: --my-anchor;
-      background-color: #123E66;;
+      background-color: #123E66;
       padding: 40px 70px;
       font-size: 30px;
       place-content: center;

--- a/css/position-try-order/demos/position-try-order/index.html
+++ b/css/position-try-order/demos/position-try-order/index.html
@@ -39,7 +39,7 @@
 
     .anchor {
       anchor-name: --my-anchor;
-      background-color: #123E66;;
+      background-color: #123E66;
       text-align: center;
       padding: 40px 60px;
       width: auto;

--- a/css/position-try-rule/demos/position-try-rule/index.html
+++ b/css/position-try-rule/demos/position-try-rule/index.html
@@ -39,7 +39,7 @@
 
     .anchor {
       anchor-name: --my-anchor;
-      background-color: #123E66;;
+      background-color: #123E66;
       width: 230px;
       height: 110px;
       font-size: 30px;

--- a/css/position-visibility/demos/position-visibility-always/index.html
+++ b/css/position-visibility/demos/position-visibility-always/index.html
@@ -54,7 +54,7 @@
 
     .anchor {
       anchor-name: --my-anchor;
-      background-color: #123E66;;
+      background-color: #123E66;
       text-align: center;
       padding: 40px;
       width: auto;

--- a/css/position-visibility/demos/position-visibility-anchors-visible/index.html
+++ b/css/position-visibility/demos/position-visibility-anchors-visible/index.html
@@ -66,7 +66,7 @@
 
     .anchor {
       anchor-name: --anchor;
-      background-color: #123E66;;
+      background-color: #123E66;
       padding: 4px 8px;
       border-radius: 6px;
     }

--- a/css/position-visibility/demos/position-visibility-no-overflow/demo.html
+++ b/css/position-visibility/demos/position-visibility-no-overflow/demo.html
@@ -54,7 +54,7 @@
 
     .anchor {
       anchor-name: --my-anchor;
-      background-color: #123E66;;
+      background-color: #123E66;
       text-align: center;
       padding: 30px 70px;
       width: auto;

--- a/html/h1-h6/demos/cakes/index.html
+++ b/html/h1-h6/demos/cakes/index.html
@@ -27,7 +27,7 @@
       min-width: 650px;
       margin: auto;
       padding: 55px 40px;
-      background-color: #FFFFFF;;
+      background-color: #FFFFFF;
     }
 
     h1,

--- a/html/h1-h6/demos/headers/index.html
+++ b/html/h1-h6/demos/headers/index.html
@@ -26,7 +26,7 @@
       min-width: 650px;
       margin: auto;
       padding: 55px 40px;
-      background-color: #FFFFFF;;
+      background-color: #FFFFFF;
     }
 
     h1,


### PR DESCRIPTION
## Что случилось

В демках опечатка: `background-color: #123E66;;` — лишняя точка с запятой. Расползлась копипастой по всем демкам про anchor positioning, а оттуда попала ещё в пару демок `html/h1-h6` и `a11y/how-to-describe-pictures`. Всего 19 мест.

Браузеру она безразлична — по спецификации пустое объявление допустимо, и все демки на проде работают. Но на локальном дев-сервере платформы Vite прогоняет инлайновые стили демок через postcss, а тот кладёт лишнюю `;` в `raws.before` следующего объявления. `postcss-csso` скармливает это css-tree вместе с объявлением и падает:

```
postcss-csso: .../flip-block/index.html:33:7: Identifier is expected
  32 |       background-color: #123E66;;
> 33 |       padding: 40px 70px;
```

Демка после этого отдаётся с 500, и в статье вместо неё пустой iframe.

## Что сделано

Убрана лишняя `;` в 19 файлах, больше ничего не тронуто. `;;` в `recipes/font-script` не трогала — там это `case` из шелл-скрипта, законный синтаксис.

## Чем проверяла

Тестов на CSS демок в репозитории нет, поэтому проверяла прогоном: скрипт гонит postcss-цепочку дев-сервера по всем 1244 html/css репозитория. До правки падало 25 демок, после — 10, и все 15 падений из-за `;;` ушли. Оставшиеся 10 — по другой причине (устаревший css-tree внутри csso не знает `@container`, `@scope`, вложенные слои и вложенность), они лечатся отдельным пулреквестом в платформе.

Демку `flip-block` открывала на локальном дев-сервере — отдаётся 200. Остальные 18 правок глазами не смотрела: правка везде одна и та же, снятие лишнего символа.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- doka-preview-6134 -->
<a href="https://content-6134.dev.doka.guide">Превью контента</a> из b63ab1cb43ce5e527e7c5c01ead7717d9c31d436 опубликовано.
<!-- /doka-preview-6134 -->
