### PR TITLE
Чинит поиск пулреквеста в превью для форков

### DIFF
--- a/.github/workflows/pr-preview.yml
+++ b/.github/workflows/pr-preview.yml
@@ -94,17 +94,57 @@ jobs:
               return
             }
 
-            // `workflow_run.pull_requests` пуст для веток из форков. Коммит
-            // лежит в `refs/pull/*/head` базового репозитория, и API находит по
-            // нему пулреквест.
-            const { data: pulls } = await github.rest.repos.listPullRequestsAssociatedWithCommit({
-              owner,
-              repo,
-              commit_sha: sha,
-            })
-            const pull = pulls.find((item) => item.state === 'open') || pulls[0]
+            // Как найти пулреквест, если `workflow_run.pull_requests` пуст —
+            // а для веток из форков он пуст всегда.
+            //
+            // Поиск по коммиту (`commits/{sha}/pulls`) для форков не работает:
+            // на коммите e02898e9 пулреквеста #6025 он не показал ни через
+            // тринадцать секунд, ни через десять минут — ноль результатов.
+            // Превью уходило в `idle`, шаги пропускались, отчёт не писался, и
+            // в описании навсегда оставалось «идут проверки». С переезда на
+            // `workflow_run` так молча ломалось каждое превью из форка, #6069
+            // и #6025 в их числе.
+            //
+            // Поэтому запасной путь — поиск по ветке-источнику: для форка это
+            // `владелец:ветка`, и он отвечает сразу. Поиск по коммиту оставлен
+            // первым: для веток самого репозитория он точнее, потому что
+            // привязан к коммиту, а не к текущей вершине ветки.
+            const headRepository = run.head_repository?.full_name || ''
+            const headOwner = headRepository.split('/')[0]
+
+            const findPull = async () => {
+              const { data: byCommit } = await github.rest.repos.listPullRequestsAssociatedWithCommit({
+                owner,
+                repo,
+                commit_sha: sha,
+              })
+              const fromCommit = byCommit.find((item) => item.state === 'open') || byCommit[0]
+              if (fromCommit) return fromCommit
+
+              if (!headOwner || !run.head_branch) return null
+              const { data: byHead } = await github.rest.pulls.list({
+                owner,
+                repo,
+                state: 'open',
+                head: `${headOwner}:${run.head_branch}`,
+                per_page: 100,
+              })
+              return byHead.find((item) => item.head.sha === sha) || byHead[0] || null
+            }
+
+            // Две попытки: обычно хватает первой, вторая — на случай, когда
+            // пулреквест только что открыли и он ещё не виден ни одной ручке.
+            let pull = null
+            for (let attempt = 1; attempt <= 2; attempt += 1) {
+              pull = await findPull()
+              if (pull) break
+              core.info(`Попытка ${attempt}: пулреквест для ${sha} не нашёлся`)
+              if (attempt < 2) await new Promise((resolve) => setTimeout(resolve, 10000))
+            }
             if (!pull) {
-              core.info(`Пулреквест по коммиту ${sha} не нашёлся`)
+              // Предупреждением, а не тихой строкой в логе: без пулреквеста
+              // заметку писать некуда, и человек останется с «идут проверки».
+              core.warning(`Пулреквест по коммиту ${sha} не нашёлся, превью не собираем`)
               core.setOutput('state', 'idle')
               return
             }


### PR DESCRIPTION
## Описание

С переезда превью на `workflow_run` (#6136) оно молча не собиралось **ни для одного пулреквеста из форка**.

Гейт ищет пулреквест по коммиту, потому что `workflow_run.pull_requests` для форков пуст. Но ручка `commits/{sha}/pulls` для коммитов из форка не отвечает вовсе: на коммите `e02898e9` пулреквеста #6025 она не показала ни через тринадцать секунд после пуша, ни через десять минут — ноль результатов. Дальше по коду это `idle`: все шаги пропускаются, отчёт не пишется, и в описании навсегда остаётся «идут проверки». Так висят #6069 и #6025.

Запасной путь — поиск по ветке-источнику. Для форка это `владелец:ветка` (`DrakesBot12:css/read-only`), и он отвечает сразу и с точным коммитом. Поиск по коммиту оставлен первым: для веток самого репозитория он точнее, потому что привязан к коммиту, а не к вершине ветки.

Заодно: если пулреквест не нашёлся, в лог уходит `::warning::` вместо тихой строки — иначе поломка выглядит как успешный прогон.

## Проверка

```
gh api repos/doka-guide/content/commits/e02898e9…/pulls        → 0
gh api 'repos/doka-guide/content/pulls?head=DrakesBot12:css/read-only' → #6025, head_sha e02898e9
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- doka-preview-6138 -->
<a href="https://content-6138.dev.doka.guide">Превью контента</a> из 724a4f1afcfd614e928465cd5b3abc4b337f0422 опубликовано.
<!-- /doka-preview-6138 -->